### PR TITLE
Fix flatten not applying with modifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
         zig: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["0.15.2", "0.16.0", "master"]' || '["0.15.2", "0.16.0"]') }}
     continue-on-error: ${{ matrix.zig == 'master' }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -14,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        zig: ["0.15.2", "0.16.0", "master"]
+        zig: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["0.15.2", "0.16.0", "master"]' || '["0.15.2", "0.16.0"]') }}
     continue-on-error: ${{ matrix.zig == 'master' }}
     steps:
       - uses: actions/checkout@v4

--- a/src/core/deserialize.zig
+++ b/src/core/deserialize.zig
@@ -748,14 +748,22 @@ test "deserialize struct with default" {
     try testing.expectEqual(@as(i32, 99), val.b);
 }
 
-test "deserialize struct with base64 (slice)" {
-    const Base64 = struct {
+test "deserialize flatten + nested .with" {
+    const B64 = struct {
         data: []const u8,
 
         pub const serde = .{
             .with = .{
                 .data = @import("../helpers/base64.zig").Base64,
             },
+        };
+    };
+
+    const Base64 = struct {
+        b64: B64,
+
+        pub const serde = .{
+            .flatten = &[_][]const u8{"b64"},
         };
     };
 
@@ -776,7 +784,7 @@ test "deserialize struct with base64 (slice)" {
 
     const val = try deserialize(Base64, arena.allocator(), &deser, .{});
 
-    try testing.expectEqualStrings(expected, val.data);
+    try testing.expectEqualStrings(expected, val.b64.data);
 }
 
 test "deserialize struct with rename" {

--- a/src/core/deserialize.zig
+++ b/src/core/deserialize.zig
@@ -252,7 +252,11 @@ fn deserializeStructFieldsSchema(
                 if (comptime opts.hasFieldWithSchema(T, field.name, schema)) {
                     const WithMod = comptime opts.getFieldWithSchema(T, field.name, schema);
                     const raw = try map.nextValue(WithMod.WireType, allocator);
-                    @field(result, field.name) = WithMod.deserialize(raw);
+                    if (@hasDecl(WithMod, "deserializeAlloc")) {
+                        @field(result, field.name) = WithMod.deserializeAlloc(raw, allocator);
+                    } else {
+                        @field(result, field.name) = WithMod.deserialize(raw);
+                    }
                 } else {
                     @field(result, field.name) = try map.nextValue(field.type, allocator);
                 }
@@ -270,7 +274,11 @@ fn deserializeStructFieldsSchema(
                             if (comptime opts.hasFieldWithSchema(T, field.name, schema)) {
                                 const WithMod = comptime opts.getFieldWithSchema(T, field.name, schema);
                                 const raw = try map.nextValue(WithMod.WireType, allocator);
-                                @field(@field(result, field.name), sf.name) = WithMod.deserialize(raw);
+                                if (@hasDecl(WithMod, "deserializeAlloc")) {
+                                    @field(@field(result, field.name), sf.name) = WithMod.deserializeAlloc(raw, allocator);
+                                } else {
+                                    @field(@field(result, field.name), sf.name) = WithMod.deserialize(raw);
+                                }
                             } else {
                                 @field(@field(result, field.name), sf.name) = try map.nextValue(sf.type, allocator);
                             }

--- a/src/core/deserialize.zig
+++ b/src/core/deserialize.zig
@@ -267,7 +267,14 @@ fn deserializeStructFieldsSchema(
                     const nested_info = @typeInfo(field.type).@"struct";
                     inline for (nested_info.fields) |sf| {
                         if (opts.matchesDeserializeName(field.type, sf.name, key, {})) {
-                            @field(@field(result, field.name), sf.name) = try map.nextValue(sf.type, allocator);
+                            if (comptime opts.hasFieldWithSchema(T, field.name, schema)) {
+                                const WithMod = comptime opts.getFieldWithSchema(T, field.name, schema);
+                                const raw = try map.nextValue(WithMod.WireType, allocator);
+                                @field(@field(result, field.name), sf.name) = WithMod.deserialize(raw);
+                            } else {
+                                @field(@field(result, field.name), sf.name) = try map.nextValue(sf.type, allocator);
+                            }
+
                             matched = true;
                         }
                     }

--- a/src/core/deserialize.zig
+++ b/src/core/deserialize.zig
@@ -225,7 +225,6 @@ fn deserializeStructFieldsSchema(
             if (@typeInfo(field.type) != .@"struct")
                 @compileError("Flatten requires a struct type, got " ++ @typeName(field.type));
             @field(result, field.name) = initWithDefaults(field.type);
-            fields_seen.set(i);
             continue;
         }
 
@@ -253,7 +252,10 @@ fn deserializeStructFieldsSchema(
                     const WithMod = comptime opts.getFieldWithSchema(T, field.name, schema);
                     const raw = try map.nextValue(WithMod.WireType, allocator);
                     if (@hasDecl(WithMod, "deserializeAlloc")) {
-                        @field(result, field.name) = WithMod.deserializeAlloc(raw, allocator) catch unreachable;
+                        @field(result, field.name) = WithMod.deserializeAlloc(raw, allocator) catch |err| switch (err) {
+                            error.OutOfMemory => return map.raiseError(error.OutOfMemory),
+                            else => return map.raiseError(error.WithFailed),
+                        };
                     } else {
                         @field(result, field.name) = WithMod.deserialize(raw);
                     }
@@ -271,11 +273,14 @@ fn deserializeStructFieldsSchema(
                     const nested_info = @typeInfo(field.type).@"struct";
                     inline for (nested_info.fields) |sf| {
                         if (opts.matchesDeserializeName(field.type, sf.name, key, {})) {
-                            if (comptime opts.hasFieldWithSchema(T, field.name, schema)) {
-                                const WithMod = comptime opts.getFieldWithSchema(T, field.name, schema);
+                            if (comptime opts.hasFieldWithSchema(field.type, sf.name, {})) {
+                                const WithMod = comptime opts.getFieldWithSchema(field.type, sf.name, {});
                                 const raw = try map.nextValue(WithMod.WireType, allocator);
                                 if (@hasDecl(WithMod, "deserializeAlloc")) {
-                                    @field(@field(result, field.name), sf.name) = WithMod.deserializeAlloc(raw, allocator) catch unreachable;
+                                    @field(@field(result, field.name), sf.name) = WithMod.deserializeAlloc(raw, allocator) catch |err| switch (err) {
+                                        error.OutOfMemory => return map.raiseError(error.OutOfMemory),
+                                        else => return map.raiseError(error.WithFailed),
+                                    };
                                 } else {
                                     @field(@field(result, field.name), sf.name) = WithMod.deserialize(raw);
                                 }
@@ -609,7 +614,7 @@ const MockMapAccess = struct {
     values: []const MockValue,
     pos: usize = 0,
 
-    pub const Error = error{ UnknownField, MissingField, UnexpectedEof, OutOfMemory, WrongType };
+    pub const Error = error{ UnknownField, MissingField, UnexpectedEof, OutOfMemory, WithFailed, WrongType };
 
     pub fn nextKey(self: *MockMapAccess, _: Allocator) Error!?[]const u8 {
         if (self.pos >= self.keys.len) return null;
@@ -636,6 +641,7 @@ const MockMapAccess = struct {
         return switch (err) {
             error.UnknownField => error.UnknownField,
             error.MissingField => error.MissingField,
+            error.WithFailed => error.WithFailed,
             else => error.WrongType,
         };
     }
@@ -689,6 +695,7 @@ const MockDeserializer = struct {
         return switch (err) {
             error.UnknownField => error.UnknownField,
             error.MissingField => error.MissingField,
+            error.WithFailed => error.WithFailed,
             else => error.WrongType,
         };
     }
@@ -767,7 +774,6 @@ test "deserialize flatten + nested .with" {
         };
     };
 
-    //  You can confirm these are equal yourself.
     const input_base64 = "VGVzdCBwYXNzZWQ/";
     const expected = "Test passed?";
 
@@ -778,13 +784,41 @@ test "deserialize flatten + nested .with" {
         },
     };
 
-    // TODO: Is this OK? Currently there's nothing in the README for this allocating behaviour.
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
 
     const val = try deserialize(Base64, arena.allocator(), &deser, .{});
 
     try testing.expectEqualStrings(expected, val.b64.data);
+}
+
+test "deserialize flatten + nested .with maps allocating helper errors" {
+    const B64 = struct {
+        data: []const u8,
+
+        pub const serde = .{
+            .with = .{
+                .data = @import("../helpers/base64.zig").Base64,
+            },
+        };
+    };
+
+    const Base64 = struct {
+        b64: B64,
+
+        pub const serde = .{
+            .flatten = &[_][]const u8{"b64"},
+        };
+    };
+
+    var deser = MockDeserializer{
+        .map = .{
+            .keys = &.{"data"},
+            .values = &.{.{ .string = "not base64" }},
+        },
+    };
+
+    try testing.expectError(error.WithFailed, deserialize(Base64, testing.allocator, &deser, .{}));
 }
 
 test "deserialize struct with rename" {

--- a/src/core/deserialize.zig
+++ b/src/core/deserialize.zig
@@ -253,7 +253,7 @@ fn deserializeStructFieldsSchema(
                     const WithMod = comptime opts.getFieldWithSchema(T, field.name, schema);
                     const raw = try map.nextValue(WithMod.WireType, allocator);
                     if (@hasDecl(WithMod, "deserializeAlloc")) {
-                        @field(result, field.name) = WithMod.deserializeAlloc(raw, allocator);
+                        @field(result, field.name) = WithMod.deserializeAlloc(raw, allocator) catch unreachable;
                     } else {
                         @field(result, field.name) = WithMod.deserialize(raw);
                     }
@@ -275,7 +275,7 @@ fn deserializeStructFieldsSchema(
                                 const WithMod = comptime opts.getFieldWithSchema(T, field.name, schema);
                                 const raw = try map.nextValue(WithMod.WireType, allocator);
                                 if (@hasDecl(WithMod, "deserializeAlloc")) {
-                                    @field(@field(result, field.name), sf.name) = WithMod.deserializeAlloc(raw, allocator);
+                                    @field(@field(result, field.name), sf.name) = WithMod.deserializeAlloc(raw, allocator) catch unreachable;
                                 } else {
                                     @field(@field(result, field.name), sf.name) = WithMod.deserialize(raw);
                                 }
@@ -746,6 +746,37 @@ test "deserialize struct with default" {
     const val = try deserialize(Def, testing.allocator, &deser, .{});
     try testing.expectEqual(@as(i32, 1), val.a);
     try testing.expectEqual(@as(i32, 99), val.b);
+}
+
+test "deserialize struct with base64 (slice)" {
+    const Base64 = struct {
+        data: []const u8,
+
+        pub const serde = .{
+            .with = .{
+                .data = @import("../helpers/base64.zig").Base64,
+            },
+        };
+    };
+
+    //  You can confirm these are equal yourself.
+    const input_base64 = "VGVzdCBwYXNzZWQ/";
+    const expected = "Test passed?";
+
+    var deser = MockDeserializer{
+        .map = .{
+            .keys = &.{"data"},
+            .values = &.{.{ .string = input_base64 }},
+        },
+    };
+
+    // TODO: Is this OK? Currently there's nothing in the README for this allocating behaviour.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const val = try deserialize(Base64, arena.allocator(), &deser, .{});
+
+    try testing.expectEqualStrings(expected, val.data);
 }
 
 test "deserialize struct with rename" {

--- a/src/core/serialize.zig
+++ b/src/core/serialize.zig
@@ -121,8 +121,8 @@ fn serializeStructSchema(comptime T: type, value: T, serializer: anytype, compti
             const nested_info = @typeInfo(field.type).@"struct";
             inline for (nested_info.fields) |sf| {
                 const nested_wire = comptime options.wireFieldNameForDir(field.type, sf.name, {}, .serialize);
-                if (comptime options.hasFieldWithSchema(T, field.name, schema)) {
-                    const WithMod = comptime options.getFieldWithSchema(T, field.name, schema);
+                if (comptime options.hasFieldWithSchema(field.type, sf.name, {})) {
+                    const WithMod = comptime options.getFieldWithSchema(field.type, sf.name, {});
                     try ss.serializeField(nested_wire, WithMod.serialize(@field(nested, sf.name)));
                 } else {
                     try ss.serializeField(nested_wire, @field(nested, sf.name));
@@ -641,6 +641,46 @@ test "serializeWith: struct containing OOB-overridden type" {
     try serializeWith(Inner, .{ .val = 99 }, &mock, map);
     // Inner should be serialized via the adapter (as int), not as a struct.
     try testing.expectEqual(TestEvent{ .int_val = 99 }, mock.events.items[0]);
+}
+
+test "serialize flatten + nested .with" {
+    const Wrapped = struct {
+        value: u8,
+
+        pub const serde = .{
+            .with = .{
+                .value = struct {
+                    pub const WireType = []const u8;
+
+                    pub fn serialize(value: u8) []const u8 {
+                        return if (value == 42) "forty-two" else "other";
+                    }
+
+                    pub fn deserialize(raw: []const u8) u8 {
+                        return if (std.mem.eql(u8, raw, "forty-two")) 42 else 0;
+                    }
+                },
+            },
+        };
+    };
+
+    const Outer = struct {
+        wrapped: Wrapped,
+
+        pub const serde = .{
+            .flatten = &[_][]const u8{"wrapped"},
+        };
+    };
+
+    var mock = MockSerializer.init(testing.allocator);
+    defer mock.deinit();
+
+    try serialize(Outer, .{ .wrapped = .{ .value = 42 } }, &mock, .{});
+
+    try testing.expectEqual(TestEvent.struct_begin, mock.events.items[0]);
+    try testing.expectEqualStrings("value", mock.events.items[1].field);
+    try testing.expectEqual(TestEvent{ .string_val = "forty-two" }, mock.events.items[2]);
+    try testing.expectEqual(TestEvent.struct_end, mock.events.items[3]);
 }
 
 test "serializeWith: no match falls through to default" {

--- a/src/core/serialize.zig
+++ b/src/core/serialize.zig
@@ -121,7 +121,12 @@ fn serializeStructSchema(comptime T: type, value: T, serializer: anytype, compti
             const nested_info = @typeInfo(field.type).@"struct";
             inline for (nested_info.fields) |sf| {
                 const nested_wire = comptime options.wireFieldNameForDir(field.type, sf.name, {}, .serialize);
-                try ss.serializeField(nested_wire, @field(nested, sf.name));
+                if (comptime options.hasFieldWithSchema(T, field.name, schema)) {
+                    const WithMod = comptime options.getFieldWithSchema(T, field.name, schema);
+                    try ss.serializeField(nested_wire, WithMod.serialize(@field(nested, sf.name)));
+                } else {
+                    try ss.serializeField(nested_wire, @field(nested, sf.name));
+                }
             }
             continue;
         }

--- a/src/formats/csv/deserializer.zig
+++ b/src/formats/csv/deserializer.zig
@@ -21,6 +21,7 @@ pub const DeserializeError = error{
     FieldCountMismatch,
     WrongType,
     Overflow,
+    WithFailed,
 };
 
 pub const Options = struct {
@@ -195,6 +196,7 @@ fn errorFromAny(err: anyerror) DeserializeError {
         error.UnexpectedEof => error.UnexpectedEof,
         error.FieldCountMismatch => error.FieldCountMismatch,
         error.OutOfMemory => error.OutOfMemory,
+        error.WithFailed => error.WithFailed,
         else => error.WrongType,
     };
 }

--- a/src/formats/json/deserializer.zig
+++ b/src/formats/json/deserializer.zig
@@ -20,6 +20,7 @@ pub const DeserializeError = error{
     TrailingData,
     WrongType,
     Overflow,
+    WithFailed,
 };
 
 pub const Options = struct {
@@ -333,6 +334,7 @@ fn errorFromAny(err: anyerror) DeserializeError {
         error.MissingField => error.MissingField,
         error.UnexpectedEof => error.UnexpectedEof,
         error.OutOfMemory => error.OutOfMemory,
+        error.WithFailed => error.WithFailed,
         else => error.WrongType,
     };
 }

--- a/src/formats/msgpack/deserializer.zig
+++ b/src/formats/msgpack/deserializer.zig
@@ -12,6 +12,7 @@ pub const DeserializeError = error{
     Overflow,
     WrongType,
     TrailingData,
+    WithFailed,
 };
 
 pub const Deserializer = struct {
@@ -450,6 +451,7 @@ fn errorFromAny(err: anyerror) DeserializeError {
         error.MissingField => error.MissingField,
         error.UnexpectedEof => error.UnexpectedEof,
         error.OutOfMemory => error.OutOfMemory,
+        error.WithFailed => error.WithFailed,
         else => error.WrongType,
     };
 }

--- a/src/formats/toml/deserializer.zig
+++ b/src/formats/toml/deserializer.zig
@@ -16,6 +16,7 @@ pub const DeserializeError = error{
     WrongType,
     InvalidNumber,
     Overflow,
+    WithFailed,
 };
 
 pub const Deserializer = struct {
@@ -363,6 +364,7 @@ fn errorFromAny(err: anyerror) DeserializeError {
         error.MissingField => error.MissingField,
         error.UnexpectedEof => error.UnexpectedEof,
         error.OutOfMemory => error.OutOfMemory,
+        error.WithFailed => error.WithFailed,
         else => error.WrongType,
     };
 }

--- a/src/formats/xml/deserializer.zig
+++ b/src/formats/xml/deserializer.zig
@@ -16,6 +16,7 @@ pub const DeserializeError = error{
     WrongType,
     Overflow,
     MalformedXml,
+    WithFailed,
 };
 
 pub const Deserializer = struct {
@@ -422,6 +423,7 @@ fn errorFromAny(err: anyerror) DeserializeError {
         error.UnexpectedEof => error.UnexpectedEof,
         error.OutOfMemory => error.OutOfMemory,
         error.MalformedXml => error.MalformedXml,
+        error.WithFailed => error.WithFailed,
         else => error.WrongType,
     };
 }

--- a/src/formats/yaml/deserializer.zig
+++ b/src/formats/yaml/deserializer.zig
@@ -16,6 +16,7 @@ pub const DeserializeError = error{
     WrongType,
     InvalidNumber,
     Overflow,
+    WithFailed,
 };
 
 pub const Deserializer = struct {
@@ -385,6 +386,7 @@ fn errorFromAny(err: anyerror) DeserializeError {
         error.MissingField => error.MissingField,
         error.UnexpectedEof => error.UnexpectedEof,
         error.OutOfMemory => error.OutOfMemory,
+        error.WithFailed => error.WithFailed,
         else => error.WrongType,
     };
 }

--- a/src/formats/zon/deserializer.zig
+++ b/src/formats/zon/deserializer.zig
@@ -14,6 +14,7 @@ pub const DeserializeError = error{
     WrongType,
     Overflow,
     TrailingData,
+    WithFailed,
 };
 
 pub const Deserializer = struct {
@@ -384,6 +385,7 @@ fn errorFromAny(err: anyerror) DeserializeError {
         error.MissingField => error.MissingField,
         error.UnexpectedEof => error.UnexpectedEof,
         error.OutOfMemory => error.OutOfMemory,
+        error.WithFailed => error.WithFailed,
         else => error.WrongType,
     };
 }


### PR DESCRIPTION
Here is a failing example from one of my projects:

```zig
pub const PublicKey = struct {
    pubkey: [Box.public_length]u8,

    pub const serde = .{
        .with = .{
            .pubkey = Serde.helpers.Base64,
        },
    };
};

pub const Peer = struct {
    /// NaCl Box public key. Should be 32 bytes in length.
    pubkey: PublicKey,
    /// A nickname for the remote peer.
    nickname: []const u8,

    pub const serde = .{
        .flatten = &[_][]const u8{"pubkey"},
    };
};
```

This should now apply modifers when using .flatten.

I also ran into problems with there being no der/ser (non-allocating) methods for Base64 encode/decode. So it only works when deserialising.

For now I might push another fix to check for a decl of `deserializeAlloc` and fall back to deserialize (for the helpers).

Thanks for the great library it's very nice to use.