### PR TITLE
Support Zig master (0.17.0-dev-*)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-15, windows-latest]
-        zig: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["0.15.2", "0.16.0", "master"]' || '["0.15.2", "0.16.0"]') }}
-    continue-on-error: ${{ matrix.zig == 'master' }}
+        zig: ["0.15.2", "0.16.0", "master"]
     steps:
       - uses: actions/checkout@v4
 
@@ -24,7 +23,10 @@ jobs:
         with:
           version: ${{ matrix.zig }}
 
+      # zig fmt on master rewrites @enumFromInt to @fromBackingInt
+      # so just ignore fmt checking on master for now?
       - name: Check formatting
+        if: matrix.zig != 'master'
         run: zig fmt --check src/ bench/ build.zig
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zig: ["0.15.2", "0.16.0"]
+        zig: ["0.15.2", "0.16.0", "master"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           baseline="benchmark-baseline-${{ matrix.zig }}.json"
           if [ "${{ github.event_name }}" = "pull_request" ] && [ -d serde-base ]; then
             if (cd serde-base && zig build -l | grep -q '^  bench'); then
-              (cd serde-base && zig build bench -- --format json --compare std_json --out "../$baseline")
+              (cd serde-base && zig build bench -Dbench-format=json -Dbench-compare-std-json -Dbench-out="../$baseline")
             else
               printf '{"schema_version":1,"results":[]}\n' > "$baseline"
             fi
@@ -73,7 +73,7 @@ jobs:
           fi
 
       - name: Run benchmarks
-        run: zig build bench -- --format json --compare std_json --baseline benchmark-baseline-${{ matrix.zig }}.json --out benchmark-results-${{ matrix.zig }}.json
+        run: zig build bench -Dbench-format=json -Dbench-compare-std-json -Dbench-baseline=benchmark-baseline-${{ matrix.zig }}.json -Dbench-out=benchmark-results-${{ matrix.zig }}.json
 
       - name: Benchmark summary
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,14 @@ jobs:
           baseline="benchmark-baseline-${{ matrix.zig }}.json"
           if [ "${{ github.event_name }}" = "pull_request" ] && [ -d serde-base ]; then
             if (cd serde-base && zig build -l | grep -q '^  bench'); then
-              (cd serde-base && zig build bench -Dbench-format=json -Dbench-compare-std-json -Dbench-out="../$baseline")
+              # Older build.zig reads bench arguments from `zig build bench -- ...`
+              # instead of -Dbench-* build options; detect which style the base
+              # branch supports before invoking it.
+              if (cd serde-base && zig build -h | grep -q 'bench-out'); then
+                (cd serde-base && zig build bench -Dbench-format=json -Dbench-compare-std-json -Dbench-out="../$baseline")
+              else
+                (cd serde-base && zig build bench -- --format json --compare std_json --out "../$baseline")
+              fi
             else
               printf '{"schema_version":1,"results":[]}\n' > "$baseline"
             fi

--- a/README.md
+++ b/README.md
@@ -918,7 +918,7 @@ fields with empty values.
 const bytes = try serde.json.toSliceWith(allocator, value, .{ .escape_js_unsafe = true });
 ```
 
-When true, U+2028 and U+2029 are escaped as ` ` / ` `. They are valid
+When true, U+2028 and U+2029 are escaped as `` / ``. They are valid
 JSON characters but illegal in JavaScript string literals; escape when embedding
 output in HTML `<script>` tags.
 

--- a/README.md
+++ b/README.md
@@ -112,24 +112,24 @@ Requires Zig 0.15.2 or later, including current Zig 0.17 development builds.
 
 Supported Zig versions:
 
-| Zig version | Status |
-|-------------|--------|
-| `0.16.0` | current stable, required in docs CI |
-| `0.15.2` | previous stable, fully supported |
+| Zig version           | Status                                                            |
+| --------------------- | ----------------------------------------------------------------- |
+| `0.16.0`              | current stable, required in docs CI                               |
+| `0.15.2`              | previous stable, fully supported                                  |
 | `0.17-dev` / `master` | supported against current development snapshots and tracked in CI |
 
 ## Formats
 
-| Format | Module | Serialize | Deserialize |
-|--------|--------|-----------|-------------|
-| JSON | `serde.json` | + | + |
-| MessagePack | `serde.msgpack` | + | + |
-| TOML | `serde.toml` | + | + |
-| YAML | `serde.yaml` | + | + |
-| XML | `serde.xml` | + | + |
-| ZON | `serde.zon` | + | + |
-| TOON | `serde.toon` | + | + |
-| CSV | `serde.csv` | + | + |
+| Format      | Module          | Serialize | Deserialize |
+| ----------- | --------------- | --------- | ----------- |
+| JSON        | `serde.json`    | +         | +           |
+| MessagePack | `serde.msgpack` | +         | +           |
+| TOML        | `serde.toml`    | +         | +           |
+| YAML        | `serde.yaml`    | +         | +           |
+| XML         | `serde.xml`     | +         | +           |
+| ZON         | `serde.zon`     | +         | +           |
+| TOON        | `serde.toon`    | +         | +           |
+| CSV         | `serde.csv`     | +         | +           |
 
 Every format exposes the same API:
 
@@ -918,7 +918,7 @@ fields with empty values.
 const bytes = try serde.json.toSliceWith(allocator, value, .{ .escape_js_unsafe = true });
 ```
 
-When true, U+2028 and U+2029 are escaped as `` / ``. They are valid
+When true, U+2028 and U+2029 are escaped as `/`. They are valid
 JSON characters but illegal in JavaScript string literals; escape when embedding
 output in HTML `<script>` tags.
 
@@ -947,14 +947,16 @@ Run the benchmark suite with:
 
 ```sh
 zig build bench
-zig build bench -- --format json
-zig build bench -- --filter json
-zig build bench -- --compare std_json
+zig build bench -Dbench-format=json
+zig build bench -Dbench-filter=json
+zig build bench -Dbench-compare-std-json
 ```
 
-Benchmark arguments are passed after `--` because Zig consumes build-step
-arguments before the project runner sees them. The runner defaults to
-`ReleaseFast` for the benchmark executable and the imported `serde` module.
+Benchmark options are passed as `-D` build options. Run `zig build --help` to see the full list (`-Dbench-format`,
+`-Dbench-filter`, `-Dbench-compare-std-json`, `-Dbench-baseline`,
+`-Dbench-threshold`, `-Dbench-out`), alongside `-Dbench-optimize` which
+controls the optimize mode for the benchmark executable and the imported
+`serde` module (defaults to the release-fast equivalent).
 
 Metrics include `ns/op`, `allocations/op`, `bytes allocated/op`, throughput
 MB/s, average output size, warm runs, and selected cold runs. JSON output also
@@ -964,14 +966,14 @@ operation so CI artifacts can be compared over time.
 Representative local run, Apple Silicon macOS, Zig 0.16.0, `ReleaseFast`,
 April 24, 2026:
 
-| Case | Operation | Implementation | ns/op | allocs/op | bytes/op | MB/s |
-|------|-----------|----------------|-------|-----------|----------|------|
-| flat struct JSON | serialize | serde | 1916.44 | 1.00 | 132.00 | 25.88 |
-| flat struct JSON | serialize | std_json | 1608.86 | 1.00 | 132.00 | 30.82 |
-| flat struct JSON | deserialize | serde | 1633.18 | 1.00 | 70.00 | 30.37 |
-| flat struct JSON | deserialize | std_json | 1769.35 | 1.00 | 256.00 | 28.03 |
-| borrowed JSON strings | deserialize | serde | 78.17 | 0.00 | 0.00 | 817.44 |
-| array of structs JSON | roundtrip | serde | 5115.59 | 2.00 | 1888.00 | 78.11 |
+| Case                  | Operation   | Implementation | ns/op   | allocs/op | bytes/op | MB/s   |
+| --------------------- | ----------- | -------------- | ------- | --------- | -------- | ------ |
+| flat struct JSON      | serialize   | serde          | 1916.44 | 1.00      | 132.00   | 25.88  |
+| flat struct JSON      | serialize   | std_json       | 1608.86 | 1.00      | 132.00   | 30.82  |
+| flat struct JSON      | deserialize | serde          | 1633.18 | 1.00      | 70.00    | 30.37  |
+| flat struct JSON      | deserialize | std_json       | 1769.35 | 1.00      | 256.00   | 28.03  |
+| borrowed JSON strings | deserialize | serde          | 78.17   | 0.00      | 0.00     | 817.44 |
+| array of structs JSON | roundtrip   | serde          | 5115.59 | 2.00      | 1888.00  | 78.11  |
 
 CI uploads benchmark baseline/result artifacts for Zig 0.15.2 and 0.16.0. The
 test matrix also runs Zig master, which currently tracks 0.17 development

--- a/bench/main.zig
+++ b/bench/main.zig
@@ -195,7 +195,7 @@ pub fn main() !void {
     const gpa = std.heap.page_allocator;
 
     const format = parseOutputFormat(options.format) orelse {
-        std.debug.print("unsupported --format '{s}', expected text or json\n", .{options.format});
+        std.debug.print("unsupported -Dbench-format='{s}', expected text or json\n", .{options.format});
         return error.InvalidArgument;
     };
 

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,8 @@ const builtin = @import("builtin");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const bench_config = parseBenchArgs(b);
+    const bench_config = BenchConfig{};
+
     const compat_source = switch (builtin.zig_version.minor) {
         15 => "src/compat.zig",
         16...std.math.maxInt(u32) => "src/compat_0_16.zig",
@@ -235,44 +236,3 @@ const BenchConfig = struct {
     threshold_percent: f64 = 10.0,
     out: []const u8 = "",
 };
-
-fn parseBenchArgs(b: *std.Build) BenchConfig {
-    var config = BenchConfig{};
-    const args = b.args orelse return config;
-    var i: usize = 0;
-    while (i < args.len) : (i += 1) {
-        const arg = args[i];
-        if (std.mem.eql(u8, arg, "--format")) {
-            i += 1;
-            if (i >= args.len) @panic("--format requires a value");
-            config.format = b.dupe(args[i]);
-        } else if (std.mem.eql(u8, arg, "--filter")) {
-            i += 1;
-            if (i >= args.len) @panic("--filter requires a value");
-            config.filter = b.dupe(args[i]);
-        } else if (std.mem.eql(u8, arg, "--compare")) {
-            i += 1;
-            if (i >= args.len) @panic("--compare requires a value");
-            if (std.mem.eql(u8, args[i], "std_json")) {
-                config.compare_std_json = true;
-            } else {
-                @panic("unsupported --compare value; expected std_json");
-            }
-        } else if (std.mem.eql(u8, arg, "--baseline")) {
-            i += 1;
-            if (i >= args.len) @panic("--baseline requires a value");
-            config.baseline = b.dupe(args[i]);
-        } else if (std.mem.eql(u8, arg, "--threshold")) {
-            i += 1;
-            if (i >= args.len) @panic("--threshold requires a value");
-            config.threshold_percent = std.fmt.parseFloat(f64, args[i]) catch @panic("invalid --threshold value");
-        } else if (std.mem.eql(u8, arg, "--out")) {
-            i += 1;
-            if (i >= args.len) @panic("--out requires a value");
-            config.out = b.dupe(args[i]);
-        } else {
-            @panic("unknown benchmark argument");
-        }
-    }
-    return config;
-}

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const bench_config = BenchConfig{};
+    const bench_config = parseBenchOptions(b);
 
     const compat_source = switch (builtin.zig_version.minor) {
         15 => "src/compat.zig",
@@ -236,3 +236,20 @@ const BenchConfig = struct {
     threshold_percent: f64 = 10.0,
     out: []const u8 = "",
 };
+
+fn parseBenchOptions(b: *std.Build) BenchConfig {
+    var config = BenchConfig{};
+    if (b.option([]const u8, "bench-format", "Benchmark output format: text or json (default: text)")) |v|
+        config.format = v;
+    if (b.option([]const u8, "bench-filter", "Only run benchmarks whose id/format/case/operation/implementation contains this substring")) |v|
+        config.filter = v;
+    if (b.option(bool, "bench-compare-std-json", "Also run std.json comparison benchmarks (default: false)")) |v|
+        config.compare_std_json = v;
+    if (b.option([]const u8, "bench-baseline", "Path to a baseline JSON file to compare results against")) |v|
+        config.baseline = v;
+    if (b.option(f64, "bench-threshold", "Regression threshold percent (default: 10.0)")) |v|
+        config.threshold_percent = v;
+    if (b.option([]const u8, "bench-out", "Write benchmark results JSON to this path")) |v|
+        config.out = v;
+    return config;
+}

--- a/build.zig
+++ b/build.zig
@@ -124,7 +124,7 @@ pub fn build(b: *std.Build) void {
         std.builtin.OptimizeMode,
         "bench-optimize",
         "Benchmark optimization mode",
-    ) orelse .ReleaseFast;
+    ) orelse if (@hasField(std.builtin.OptimizeMode, "fast")) .fast else .ReleaseFast;
     const bench_compat_mod = b.createModule(.{
         .root_source_file = b.path(compat_source),
         .target = target,

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -280,7 +280,9 @@ pub fn zlibDecompress(allocator: std.mem.Allocator, input: []const u8, expected_
     const actual = decompressor.reader.streamRemaining(&sink) catch return error.InvalidCompressedData;
     if (actual != expected_len or decompressor.err != null or source.seek != source.end) return error.InvalidCompressedData;
     const wire_adler = switch (decompressor.container_metadata) {
-        .zlib => |zlib| zlib.adler,
+        // Zig 0.15's Decompress reads the big-endian adler32 footer as
+        // little-endian; swap it back to the on-wire value.
+        .zlib => |zlib| @byteSwap(zlib.adler),
         else => unreachable,
     };
     if (wire_adler != adler32(output[0..expected_len])) return error.InvalidCompressedData;

--- a/src/core/deserialize.zig
+++ b/src/core/deserialize.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const compat = @import("compat");
+const reflect = @import("../reflect.zig");
 const kind_mod = @import("kind.zig");
 const opts = @import("options.zig");
 
@@ -73,7 +74,7 @@ pub fn deserializeSchema(
 }
 
 fn findOobAdapter(comptime T: type, comptime map: anytype) ?type {
-    inline for (@typeInfo(@TypeOf(map)).@"struct".fields) |field| {
+    inline for (reflect.structFields(@TypeOf(map))) |field| {
         const entry = @field(map, field.name);
         if (entry[0] == T) return entry[1];
     }
@@ -94,7 +95,7 @@ fn deserializeEnumSchema(comptime T: type, allocator: Allocator, deserializer: a
     // With rename/alias: read string and match in core.
     const name = try deserializer.deserializeString(allocator);
     defer freeAllocated([]const u8, name, allocator);
-    inline for (@typeInfo(T).@"enum".fields) |field| {
+    inline for (reflect.enumFields(T)) |field| {
         if (opts.matchesDeserializeName(T, field.name, name, schema)) {
             return @enumFromInt(field.value);
         }
@@ -141,15 +142,15 @@ fn deserializeTupleSchema(
     comptime map: anytype,
 ) @TypeOf(deserializer.*).Error!T {
     _ = map;
-    const info = @typeInfo(T).@"struct";
+    const fields = reflect.structFields(T);
     var result: T = undefined;
     var seq = try deserializer.deserializeSeqAccess();
-    inline for (info.fields) |field| {
+    inline for (fields) |field| {
         @field(result, field.name) = try seq.nextElement(field.type, allocator) orelse
             return deserializer.raiseError(error.UnexpectedEof);
     }
-    if (info.fields.len > 0) {
-        if (try seq.nextElement(info.fields[0].type, allocator) != null)
+    if (fields.len > 0) {
+        if (try seq.nextElement(fields[0].type, allocator) != null)
             return deserializer.raiseError(error.UnexpectedToken);
     }
     return result;
@@ -169,7 +170,7 @@ fn freeAllocated(comptime T: type, value: T, allocator: Allocator) void {
             allocator.destroy(value);
         },
         .@"struct" => {
-            inline for (@typeInfo(T).@"struct".fields) |field| {
+            inline for (reflect.structFields(T)) |field| {
                 freeAllocated(field.type, @field(value, field.name), allocator);
             }
         },
@@ -187,8 +188,7 @@ fn freeAllocated(comptime T: type, value: T, allocator: Allocator) void {
 }
 
 fn freeStructFields(comptime T: type, result: *T, fields_seen: anytype, allocator: Allocator) void {
-    const info = @typeInfo(T).@"struct";
-    inline for (info.fields, 0..) |field, i| {
+    inline for (reflect.structFields(T), 0..) |field, i| {
         if (fields_seen.isSet(i)) {
             freeAllocated(field.type, @field(result, field.name), allocator);
         }
@@ -203,13 +203,13 @@ fn deserializeStructFieldsSchema(
     comptime oob_map: anytype,
 ) @TypeOf(deserializer.*).Error!T {
     _ = oob_map;
-    const info = @typeInfo(T).@"struct";
+    const fields = reflect.structFields(T);
 
     var result: T = undefined;
-    var fields_seen = compat.staticBitSetEmpty(info.fields.len);
+    var fields_seen = compat.staticBitSetEmpty(fields.len);
     errdefer freeStructFields(T, &result, fields_seen, allocator);
 
-    inline for (info.fields, 0..) |field, i| {
+    inline for (fields, 0..) |field, i| {
         if (comptime opts.shouldSkipFieldSchema(T, field.name, .deserialize, schema)) {
             if (comptime field.defaultValue()) |dv| {
                 @field(result, field.name) = dv;
@@ -243,7 +243,7 @@ fn deserializeStructFieldsSchema(
     while (try map.nextKey(allocator)) |key| {
         var matched = false;
 
-        inline for (info.fields, 0..) |field, i| {
+        inline for (fields, 0..) |field, i| {
             if (comptime opts.shouldSkipFieldSchema(T, field.name, .deserialize, schema)) continue;
             if (comptime opts.isFlattenedFieldSchema(T, field.name, schema)) continue;
 
@@ -268,10 +268,9 @@ fn deserializeStructFieldsSchema(
         }
 
         if (!matched) {
-            inline for (info.fields) |field| {
+            inline for (fields) |field| {
                 if (comptime opts.isFlattenedFieldSchema(T, field.name, schema)) {
-                    const nested_info = @typeInfo(field.type).@"struct";
-                    inline for (nested_info.fields) |sf| {
+                    inline for (reflect.structFields(field.type)) |sf| {
                         if (opts.matchesDeserializeName(field.type, sf.name, key, {})) {
                             if (comptime opts.hasFieldWithSchema(field.type, sf.name, {})) {
                                 const WithMod = comptime opts.getFieldWithSchema(field.type, sf.name, {});
@@ -304,7 +303,7 @@ fn deserializeStructFieldsSchema(
     }
 
     // Validate required fields. Flattened fields already initialized above.
-    inline for (info.fields, 0..) |field, i| {
+    inline for (fields, 0..) |field, i| {
         if (comptime opts.isFlattenedFieldSchema(T, field.name, schema)) continue;
         if (!fields_seen.isSet(i)) {
             if (@typeInfo(field.type) == .optional) {
@@ -319,9 +318,8 @@ fn deserializeStructFieldsSchema(
 }
 
 fn initWithDefaults(comptime T: type) T {
-    const info = @typeInfo(T).@"struct";
     var result: T = undefined;
-    inline for (info.fields) |field| {
+    inline for (reflect.structFields(T)) |field| {
         if (comptime field.defaultValue()) |dv| {
             @field(result, field.name) = dv;
         } else if (@typeInfo(field.type) == .optional) {
@@ -358,13 +356,13 @@ fn deserializeUnionExternalSchema(
     deserializer: anytype,
     comptime schema: anytype,
 ) @TypeOf(deserializer.*).Error!T {
-    const info = @typeInfo(T).@"union";
+    const fields = reflect.unionFields(T);
 
     {
         const saved = deserializer.*;
         if (deserializer.deserializeString(allocator)) |name| {
             defer freeAllocated([]const u8, name, allocator);
-            inline for (info.fields) |field| {
+            inline for (fields) |field| {
                 if (field.type == void and opts.matchesDeserializeName(T, field.name, name, schema)) {
                     return @unionInit(T, field.name, {});
                 }
@@ -378,7 +376,7 @@ fn deserializeUnionExternalSchema(
     var map = try deserializer.deserializeStruct(T);
     const key = (try map.nextKey(allocator)) orelse return deserializer.raiseError(error.MissingField);
 
-    inline for (info.fields) |field| {
+    inline for (fields) |field| {
         if (opts.matchesDeserializeName(T, field.name, key, schema)) {
             if (field.type == void) {
                 try map.skipValue();
@@ -402,7 +400,7 @@ fn deserializeUnionInternalSchema(
     deserializer: anytype,
     comptime schema: anytype,
 ) @TypeOf(deserializer.*).Error!T {
-    const info = @typeInfo(T).@"union";
+    const fields = reflect.unionFields(T);
     const tag_field = comptime opts.getTagFieldSchema(T, schema);
 
     var map = try deserializer.deserializeStruct(T);
@@ -418,7 +416,7 @@ fn deserializeUnionInternalSchema(
 
     const name = tag_name orelse return deserializer.raiseError(error.MissingField);
 
-    inline for (info.fields) |field| {
+    inline for (fields) |field| {
         if (opts.matchesDeserializeName(T, field.name, name, schema)) {
             if (field.type == void) {
                 while (try map.nextKey(allocator)) |_| {
@@ -427,15 +425,15 @@ fn deserializeUnionInternalSchema(
                 return @unionInit(T, field.name, {});
             }
 
-            const payload_info = @typeInfo(field.type);
-            if (payload_info != .@"struct")
+            if (@typeInfo(field.type) != .@"struct")
                 @compileError("Internal tagging requires struct payloads for " ++ field.name);
+            const payload_fields = reflect.structFields(field.type);
 
             var result: field.type = undefined;
-            var fields_seen = compat.staticBitSetEmpty(payload_info.@"struct".fields.len);
+            var fields_seen = compat.staticBitSetEmpty(payload_fields.len);
             errdefer freeStructFields(field.type, &result, fields_seen, allocator);
 
-            inline for (payload_info.@"struct".fields, 0..) |sf, i| {
+            inline for (payload_fields, 0..) |sf, i| {
                 if (comptime sf.defaultValue()) |dv| {
                     @field(result, sf.name) = dv;
                     fields_seen.set(i);
@@ -444,7 +442,7 @@ fn deserializeUnionInternalSchema(
 
             while (try map.nextKey(allocator)) |field_key| {
                 var matched = false;
-                inline for (payload_info.@"struct".fields, 0..) |sf, i| {
+                inline for (payload_fields, 0..) |sf, i| {
                     if (std.mem.eql(u8, field_key, sf.name)) {
                         @field(result, sf.name) = try map.nextValue(sf.type, allocator);
                         fields_seen.set(i);
@@ -454,7 +452,7 @@ fn deserializeUnionInternalSchema(
                 if (!matched) try map.skipValue();
             }
 
-            inline for (payload_info.@"struct".fields, 0..) |sf, i| {
+            inline for (payload_fields, 0..) |sf, i| {
                 if (!fields_seen.isSet(i)) {
                     if (@typeInfo(sf.type) == .optional) {
                         @field(result, sf.name) = null;
@@ -477,7 +475,7 @@ fn deserializeUnionAdjacentSchema(
     deserializer: anytype,
     comptime schema: anytype,
 ) @TypeOf(deserializer.*).Error!T {
-    const info = @typeInfo(T).@"union";
+    const fields = reflect.unionFields(T);
     const tag_field = comptime opts.getTagFieldSchema(T, schema);
     const content_field = comptime opts.getContentFieldSchema(T, schema);
 
@@ -493,7 +491,7 @@ fn deserializeUnionAdjacentSchema(
         } else if (std.mem.eql(u8, key, content_field)) {
             const name = tag_name orelse return deserializer.raiseError(error.UnexpectedToken);
             found_content = true;
-            inline for (info.fields) |field| {
+            inline for (fields) |field| {
                 if (opts.matchesDeserializeName(T, field.name, name, schema)) {
                     if (field.type == void) {
                         try map.skipValue();
@@ -513,7 +511,7 @@ fn deserializeUnionAdjacentSchema(
 
     if (tag_name) |name| {
         if (!found_content) {
-            inline for (info.fields) |field| {
+            inline for (fields) |field| {
                 if (field.type == void and opts.matchesDeserializeName(T, field.name, name, schema))
                     return @unionInit(T, field.name, {});
             }
@@ -585,9 +583,7 @@ fn deserializeUnionUntaggedSchema(
     deserializer: anytype,
     comptime map: anytype,
 ) @TypeOf(deserializer.*).Error!T {
-    const info = @typeInfo(T).@"union";
-
-    inline for (info.fields) |field| {
+    inline for (reflect.unionFields(T)) |field| {
         const saved = deserializer.*;
         if (field.type == void) {
             if (deserializer.deserializeVoid()) {

--- a/src/core/deserialize.zig
+++ b/src/core/deserialize.zig
@@ -186,12 +186,12 @@ pub fn freeAllocated(comptime T: type, value: T, allocator: Allocator) void {
             }
         },
         .tuple => {
-            inline for (@typeInfo(T).@"struct".fields) |field| {
+            inline for (reflect.structFields(T)) |field| {
                 freeAllocated(field.type, @field(value, field.name), allocator);
             }
         },
         .@"union" => {
-            inline for (@typeInfo(T).@"union".fields) |field| {
+            inline for (reflect.unionFields(T)) |field| {
                 if (value == @field(T, field.name) and field.type != void)
                     freeAllocated(field.type, @field(value, field.name), allocator);
             }

--- a/src/core/kind.zig
+++ b/src/core/kind.zig
@@ -127,6 +127,8 @@ test "string kinds" {
     try testing.expectEqual(.string, comptime typeKind([]const u8));
     try testing.expectEqual(.string, comptime typeKind([]u8));
     try testing.expectEqual(.string, comptime typeKind([:0]const u8));
+    // Sentinel-terminated many-pointer, e.g. a C string literal's type.
+    try testing.expectEqual(.string, comptime typeKind([*:0]const u8));
 }
 
 test "container kinds" {

--- a/src/core/kind.zig
+++ b/src/core/kind.zig
@@ -47,7 +47,7 @@ fn classifyPointer(comptime p: std.builtin.Type.Pointer) Kind {
         return .slice;
     }
     // Sentinel-terminated pointer to u8 → string.
-    if (p.size == .many and p.child == u8 and p.sentinel != null)
+    if (p.size == .many and p.child == u8 and p.sentinel() != null)
         return .string;
     if (p.size == .one)
         return .pointer;

--- a/src/core/options.zig
+++ b/src/core/options.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const rename_mod = @import("../helpers/rename.zig");
+const reflect = @import("../reflect.zig");
 
 pub const NamingConvention = rename_mod.NamingConvention;
 pub const convertCase = rename_mod.convertCase;
@@ -239,9 +240,8 @@ pub fn countSerializableFields(comptime T: type) usize {
 }
 
 pub fn countSerializableFieldsSchema(comptime T: type, comptime schema: anytype) usize {
-    const info = @typeInfo(T).@"struct";
     var count: usize = 0;
-    for (info.fields) |field| {
+    for (reflect.structFields(T)) |field| {
         if (!shouldSkipFieldSchema(T, field.name, .serialize, schema))
             count += 1;
     }

--- a/src/core/serialize.zig
+++ b/src/core/serialize.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const kind_mod = @import("kind.zig");
 const options = @import("options.zig");
 const compat = @import("compat");
+const reflect = @import("../reflect.zig");
 
 const Kind = kind_mod.Kind;
 const Child = kind_mod.Child;
@@ -72,7 +73,7 @@ pub fn serializeSchema(
 }
 
 fn findOobAdapter(comptime T: type, comptime map: anytype) ?type {
-    inline for (@typeInfo(@TypeOf(map)).@"struct".fields) |field| {
+    inline for (reflect.structFields(@TypeOf(map))) |field| {
         const entry = @field(map, field.name);
         if (entry[0] == T) return entry[1];
     }
@@ -107,19 +108,16 @@ fn serializeSliceSchema(comptime T: type, value: T, serializer: anytype, comptim
 
 fn serializeStructSchema(comptime T: type, value: T, serializer: anytype, comptime schema: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     _ = map;
-    const info = @typeInfo(T).@"struct";
-
     var ss = try serializer.beginStruct();
 
-    inline for (info.fields) |field| {
+    inline for (reflect.structFields(T)) |field| {
         if (comptime options.shouldSkipFieldSchema(T, field.name, .serialize, schema)) continue;
 
         if (comptime options.isFlattenedFieldSchema(T, field.name, schema)) {
             if (@typeInfo(field.type) != .@"struct")
                 @compileError("Flatten requires a struct type, got " ++ @typeName(field.type));
             const nested = @field(value, field.name);
-            const nested_info = @typeInfo(field.type).@"struct";
-            inline for (nested_info.fields) |sf| {
+            inline for (reflect.structFields(field.type)) |sf| {
                 const nested_wire = comptime options.wireFieldNameForDir(field.type, sf.name, {}, .serialize);
                 if (comptime options.hasFieldWithSchema(field.type, sf.name, {})) {
                     const WithMod = comptime options.getFieldWithSchema(field.type, sf.name, {});
@@ -154,9 +152,8 @@ fn serializeStructSchema(comptime T: type, value: T, serializer: anytype, compti
 }
 
 fn serializeTupleSchema(comptime T: type, value: T, serializer: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
-    const info = @typeInfo(T).@"struct";
     var arr = try serializer.beginArray();
-    inline for (info.fields) |field| {
+    inline for (reflect.structFields(T)) |field| {
         try serializeSchema(field.type, @field(value, field.name), &arr, {}, map);
     }
     return arr.end();
@@ -177,8 +174,7 @@ fn serializeUnionSchema(comptime T: type, value: T, serializer: anytype, comptim
 
 fn serializeUnionExternalSchema(comptime T: type, value: T, serializer: anytype, comptime schema: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     _ = map;
-    const info = @typeInfo(T).@"union";
-    inline for (info.fields) |field| {
+    inline for (reflect.unionFields(T)) |field| {
         if (value == @field(T, field.name)) {
             const wire_name = comptime options.wireFieldNameForDir(T, field.name, schema, .serialize);
             if (field.type == void) {
@@ -194,9 +190,8 @@ fn serializeUnionExternalSchema(comptime T: type, value: T, serializer: anytype,
 }
 
 fn serializeUnionInternalSchema(comptime T: type, value: T, serializer: anytype, comptime schema: anytype) @TypeOf(serializer.*).Error!void {
-    const info = @typeInfo(T).@"union";
     const tag_field_name = comptime options.getTagFieldSchema(T, schema);
-    inline for (info.fields) |field| {
+    inline for (reflect.unionFields(T)) |field| {
         if (value == @field(T, field.name)) {
             const wire_name = comptime options.wireFieldNameForDir(T, field.name, schema, .serialize);
             var ss = try serializer.beginStruct();
@@ -204,11 +199,10 @@ fn serializeUnionInternalSchema(comptime T: type, value: T, serializer: anytype,
             if (field.type == void) {
                 return ss.end();
             } else {
-                const payload_info = @typeInfo(field.type);
-                if (payload_info != .@"struct")
+                if (@typeInfo(field.type) != .@"struct")
                     @compileError("Internal tagging requires struct payloads, got " ++ @typeName(field.type));
                 const payload = @field(value, field.name);
-                inline for (payload_info.@"struct".fields) |sf| {
+                inline for (reflect.structFields(field.type)) |sf| {
                     try ss.serializeField(sf.name, @field(payload, sf.name));
                 }
                 return ss.end();
@@ -218,10 +212,9 @@ fn serializeUnionInternalSchema(comptime T: type, value: T, serializer: anytype,
 }
 
 fn serializeUnionAdjacentSchema(comptime T: type, value: T, serializer: anytype, comptime schema: anytype) @TypeOf(serializer.*).Error!void {
-    const info = @typeInfo(T).@"union";
     const tag_field_name = comptime options.getTagFieldSchema(T, schema);
     const content_field_name = comptime options.getContentFieldSchema(T, schema);
-    inline for (info.fields) |field| {
+    inline for (reflect.unionFields(T)) |field| {
         if (value == @field(T, field.name)) {
             const wire_name = comptime options.wireFieldNameForDir(T, field.name, schema, .serialize);
             var ss = try serializer.beginStruct();
@@ -236,8 +229,7 @@ fn serializeUnionAdjacentSchema(comptime T: type, value: T, serializer: anytype,
 }
 
 fn serializeUnionUntaggedSchema(comptime T: type, value: T, serializer: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
-    const info = @typeInfo(T).@"union";
-    inline for (info.fields) |field| {
+    inline for (reflect.unionFields(T)) |field| {
         if (value == @field(T, field.name)) {
             if (field.type == void) {
                 return serializer.serializeNull();
@@ -254,7 +246,7 @@ fn serializeEnumSchema(comptime T: type, value: T, serializer: anytype, comptime
         const tag_type = @typeInfo(T).@"enum".tag_type;
         return serializer.serializeInt(@as(tag_type, @intFromEnum(value)));
     }
-    inline for (@typeInfo(T).@"enum".fields) |field| {
+    inline for (reflect.enumFields(T)) |field| {
         if (@intFromEnum(value) == field.value) {
             const wire_name = comptime options.wireFieldNameForDir(T, field.name, schema, .serialize);
             return serializer.serializeString(wire_name);

--- a/src/core/value.zig
+++ b/src/core/value.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const kind_mod = @import("kind.zig");
 const serialize_mod = @import("serialize.zig");
+const reflect = @import("../reflect.zig");
 
 const Allocator = std.mem.Allocator;
 const Kind = kind_mod.Kind;
@@ -102,8 +103,8 @@ pub const Value = union(enum) {
                 return .{ .array = arr };
             },
             .@"struct" => {
-                const info = @typeInfo(T).@"struct";
-                var entries = try allocator.alloc(Entry, info.fields.len);
+                const fields = reflect.structFields(T);
+                var entries = try allocator.alloc(Entry, fields.len);
                 errdefer {
                     for (entries) |e| {
                         allocator.free(e.key);
@@ -111,7 +112,7 @@ pub const Value = union(enum) {
                     }
                     allocator.free(entries);
                 }
-                inline for (info.fields, 0..) |field, i| {
+                inline for (fields, 0..) |field, i| {
                     const key = try allocator.alloc(u8, field.name.len);
                     @memcpy(key, field.name);
                     entries[i] = .{
@@ -122,8 +123,7 @@ pub const Value = union(enum) {
                 return .{ .object = entries };
             },
             .@"union" => {
-                const info = @typeInfo(T).@"union";
-                inline for (info.fields) |field| {
+                inline for (reflect.unionFields(T)) |field| {
                     if (value == @field(T, field.name)) {
                         if (field.type == void) {
                             const key = try allocator.alloc(u8, field.name.len);
@@ -145,13 +145,13 @@ pub const Value = union(enum) {
                 return .null;
             },
             .tuple => {
-                const info = @typeInfo(T).@"struct";
-                var arr = try allocator.alloc(Value, info.fields.len);
+                const fields = reflect.structFields(T);
+                var arr = try allocator.alloc(Value, fields.len);
                 errdefer {
                     for (arr) |a| a.deinit(allocator);
                     allocator.free(arr);
                 }
-                inline for (info.fields, 0..) |field, i| {
+                inline for (fields, 0..) |field, i| {
                     arr[i] = try fromAny(field.type, @field(value, field.name), allocator);
                 }
                 return .{ .array = arr };
@@ -230,7 +230,7 @@ pub const Value = union(enum) {
             },
             .@"enum" => return switch (self) {
                 .string => |s| {
-                    inline for (@typeInfo(T).@"enum".fields) |field| {
+                    inline for (reflect.enumFields(T)) |field| {
                         if (std.mem.eql(u8, s, field.name))
                             return @enumFromInt(field.value);
                     }
@@ -239,11 +239,10 @@ pub const Value = union(enum) {
                 else => error.WrongType,
             },
             .@"struct" => {
-                const info = @typeInfo(T).@"struct";
                 switch (self) {
                     .object => |entries| {
                         var result: T = undefined;
-                        inline for (info.fields) |field| {
+                        inline for (reflect.structFields(T)) |field| {
                             var found = false;
                             for (entries) |e| {
                                 if (std.mem.eql(u8, e.key, field.name)) {
@@ -307,12 +306,12 @@ pub const Value = union(enum) {
                 return ptr;
             },
             .tuple => {
-                const info = @typeInfo(T).@"struct";
+                const fields = reflect.structFields(T);
                 switch (self) {
                     .array => |arr| {
-                        if (arr.len != info.fields.len) return error.WrongType;
+                        if (arr.len != fields.len) return error.WrongType;
                         var result: T = undefined;
-                        inline for (info.fields, 0..) |field, i| {
+                        inline for (fields, 0..) |field, i| {
                             @field(result, field.name) = try arr[i].toType(field.type, allocator);
                         }
                         return result;
@@ -321,13 +320,12 @@ pub const Value = union(enum) {
                 }
             },
             .@"union" => {
-                const info = @typeInfo(T).@"union";
                 switch (self) {
                     // External tagging: single-entry object {"variant": payload}
                     .object => |entries| {
                         if (entries.len != 1) return error.WrongType;
                         const name = entries[0].key;
-                        inline for (info.fields) |field| {
+                        inline for (reflect.unionFields(T)) |field| {
                             if (std.mem.eql(u8, name, field.name)) {
                                 if (field.type == void) {
                                     return @unionInit(T, field.name, {});
@@ -341,7 +339,7 @@ pub const Value = union(enum) {
                     },
                     // Void variant as bare string.
                     .string => |s| {
-                        inline for (info.fields) |field| {
+                        inline for (reflect.unionFields(T)) |field| {
                             if (field.type == void and std.mem.eql(u8, s, field.name)) {
                                 return @unionInit(T, field.name, {});
                             }

--- a/src/formats/csv/deserializer.zig
+++ b/src/formats/csv/deserializer.zig
@@ -3,6 +3,7 @@ const compat = @import("compat");
 const scanner_mod = @import("scanner.zig");
 const core_deserialize = @import("../../core/deserialize.zig");
 const kind_mod = @import("../../core/kind.zig");
+const reflect = @import("../../reflect.zig");
 
 const Scanner = scanner_mod.Scanner;
 const Field = scanner_mod.Field;
@@ -170,7 +171,7 @@ fn parseField(comptime T: type, field: Field, allocator: Allocator) DeserializeE
                 const int_val = std.fmt.parseInt(tag_type, trimmed, 10) catch return error.InvalidNumber;
                 return compat.intToEnum(T, int_val) orelse return error.UnexpectedToken;
             }
-            inline for (@typeInfo(T).@"enum".fields) |f| {
+            inline for (reflect.enumFields(T)) |f| {
                 if (std.mem.eql(u8, trimmed, f.name))
                     return @enumFromInt(f.value);
             }

--- a/src/formats/csv/mod.zig
+++ b/src/formats/csv/mod.zig
@@ -13,6 +13,7 @@ const core_serialize = @import("../../core/serialize.zig");
 const core_deserialize = @import("../../core/deserialize.zig");
 const kind_mod = @import("../../core/kind.zig");
 const options = @import("../../core/options.zig");
+const reflect = @import("../../reflect.zig");
 
 pub const Scanner = scanner_mod.Scanner;
 pub const Dialect = scanner_mod.Dialect;
@@ -162,8 +163,7 @@ pub fn fromReaderSchema(comptime T: type, allocator: std.mem.Allocator, reader: 
 }
 
 fn writeHeaderRowSchema(comptime T: type, ser: *Serializer, comptime schema: anytype) SerializeError!void {
-    const info = @typeInfo(T).@"struct";
-    inline for (info.fields) |field| {
+    inline for (reflect.structFields(T)) |field| {
         if (comptime options.shouldSkipFieldSchema(T, field.name, .serialize, schema)) continue;
         const wire_name = comptime options.wireFieldNameForDir(T, field.name, schema, .serialize);
         try ser.serializeString(wire_name);
@@ -224,8 +224,7 @@ pub fn fromSliceWith(comptime T: type, allocator: std.mem.Allocator, input: []co
 }
 
 fn writeHeaderRow(comptime T: type, ser: *Serializer) SerializeError!void {
-    const info = @typeInfo(T).@"struct";
-    inline for (info.fields) |field| {
+    inline for (reflect.structFields(T)) |field| {
         if (comptime options.shouldSkipField(T, field.name, .serialize)) continue;
         const wire_name = comptime options.wireFieldNameForDir(T, field.name, {}, .serialize);
         try ser.serializeString(wire_name);

--- a/src/formats/json/deserializer.zig
+++ b/src/formats/json/deserializer.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const scanner_mod = @import("scanner.zig");
 const core_deserialize = @import("../../core/deserialize.zig");
+const reflect = @import("../../reflect.zig");
 
 const Scanner = scanner_mod.Scanner;
 const Token = scanner_mod.Token;
@@ -154,7 +155,7 @@ pub const Deserializer = struct {
         const tok = try self.scanner.next();
         switch (tok) {
             .string => |raw| {
-                inline for (@typeInfo(T).@"enum".fields) |field| {
+                inline for (reflect.enumFields(T)) |field| {
                     if (std.mem.eql(u8, raw, field.name))
                         return @enumFromInt(field.value);
                 }
@@ -165,12 +166,12 @@ pub const Deserializer = struct {
     }
 
     pub fn deserializeUnion(self: *Deserializer, comptime T: type, allocator: Allocator) Error!T {
-        const info = @typeInfo(T).@"union";
+        const fields = reflect.unionFields(T);
         const tok = try self.scanner.peek();
         if (tok == .string) {
             const str_tok = try self.scanner.next();
             const name = str_tok.string;
-            inline for (info.fields) |field| {
+            inline for (fields) |field| {
                 if (field.type == void and std.mem.eql(u8, name, field.name)) {
                     return @unionInit(T, field.name, {});
                 }
@@ -185,7 +186,7 @@ pub const Deserializer = struct {
         const variant_name = key_tok.string;
         try self.scanner.expectColon();
 
-        inline for (info.fields) |field| {
+        inline for (fields) |field| {
             if (std.mem.eql(u8, variant_name, field.name)) {
                 if (field.type == void) {
                     const val_tok = try self.scanner.next();

--- a/src/formats/msgpack/deserializer.zig
+++ b/src/formats/msgpack/deserializer.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const core_deserialize = @import("../../core/deserialize.zig");
+const reflect = @import("../../reflect.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -104,7 +105,7 @@ pub const Deserializer = struct {
         const tag = try self.readByte();
         const len = readStrLen(tag, self) catch return error.WrongType;
         const raw = try self.readSlice(len);
-        inline for (@typeInfo(T).@"enum".fields) |field| {
+        inline for (reflect.enumFields(T)) |field| {
             if (std.mem.eql(u8, raw, field.name))
                 return @enumFromInt(field.value);
         }
@@ -112,7 +113,7 @@ pub const Deserializer = struct {
     }
 
     pub fn deserializeUnion(self: *Deserializer, comptime T: type, allocator: Allocator) Error!T {
-        const info = @typeInfo(T).@"union";
+        const fields = reflect.unionFields(T);
 
         // Void variants may be encoded as bare strings.
         if (self.pos < self.input.len) {
@@ -128,7 +129,7 @@ pub const Deserializer = struct {
                     self.pos = saved;
                     return error.WrongType;
                 };
-                inline for (info.fields) |field| {
+                inline for (fields) |field| {
                     if (field.type == void and std.mem.eql(u8, name, field.name)) {
                         return @unionInit(T, field.name, {});
                     }
@@ -146,7 +147,7 @@ pub const Deserializer = struct {
         const key_len = readStrLen(key_tag, self) catch return error.WrongType;
         const variant_name = try self.readSlice(key_len);
 
-        inline for (info.fields) |field| {
+        inline for (fields) |field| {
             if (std.mem.eql(u8, variant_name, field.name)) {
                 if (field.type == void) {
                     const nil_tag = try self.readByte();

--- a/src/formats/toml/deserializer.zig
+++ b/src/formats/toml/deserializer.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const compat = @import("compat");
 const parser_mod = @import("parser.zig");
 const core_deserialize = @import("../../core/deserialize.zig");
+const reflect = @import("../../reflect.zig");
 
 const Allocator = std.mem.Allocator;
 const Value = parser_mod.Value;
@@ -176,7 +177,7 @@ fn deserializeValue(comptime T: type, val: *const Value, allocator: Allocator) D
                 return compat.intToEnum(T, int_val) orelse return error.UnexpectedToken;
             }
             if (val.* != .string) return error.WrongType;
-            inline for (@typeInfo(T).@"enum".fields) |field| {
+            inline for (reflect.enumFields(T)) |field| {
                 if (std.mem.eql(u8, val.string, field.name))
                     return @enumFromInt(field.value);
             }
@@ -235,11 +236,9 @@ fn deserializeValue(comptime T: type, val: *const Value, allocator: Allocator) D
 }
 
 fn deserializeUnionFromValue(val: *const Value, comptime T: type, allocator: Allocator) DeserializeError!T {
-    const info = @typeInfo(T).@"union";
-
     // Void variants from string.
     if (val.* == .string) {
-        inline for (info.fields) |field| {
+        inline for (reflect.unionFields(T)) |field| {
             if (field.type == void and std.mem.eql(u8, val.string, field.name)) {
                 return @unionInit(T, field.name, {});
             }
@@ -256,14 +255,12 @@ fn deserializeUnionFromValue(val: *const Value, comptime T: type, allocator: All
 }
 
 fn deserializeUnionFromTable(table: *const Table, comptime T: type, allocator: Allocator) DeserializeError!T {
-    const info = @typeInfo(T).@"union";
-
     if (table.count() != 1) return error.WrongType;
     var it = table.iterator();
     const entry = it.next().?;
     const variant_name = entry.key_ptr.*;
 
-    inline for (info.fields) |field| {
+    inline for (reflect.unionFields(T)) |field| {
         if (std.mem.eql(u8, variant_name, field.name)) {
             if (field.type == void) {
                 return @unionInit(T, field.name, {});
@@ -317,7 +314,7 @@ const ValueDeserializer = struct {
 
     pub fn deserializeEnum(self: *ValueDeserializer, comptime T: type) Error!T {
         if (self.val.* != .string) return error.WrongType;
-        inline for (@typeInfo(T).@"enum".fields) |field| {
+        inline for (reflect.enumFields(T)) |field| {
             if (std.mem.eql(u8, self.val.string, field.name))
                 return @enumFromInt(field.value);
         }

--- a/src/formats/toml/serializer.zig
+++ b/src/formats/toml/serializer.zig
@@ -3,6 +3,7 @@ const compat = @import("compat");
 const core_serialize = @import("../../core/serialize.zig");
 const kind_mod = @import("../../core/kind.zig");
 const options = @import("../../core/options.zig");
+const reflect = @import("../../reflect.zig");
 
 const Allocator = std.mem.Allocator;
 const Kind = kind_mod.Kind;
@@ -390,9 +391,8 @@ pub const ArraySerializer = struct {
 };
 
 fn unionHasPayload(comptime T: type) bool {
-    const info = @typeInfo(T);
-    if (info != .@"union") return false;
-    for (info.@"union".fields) |field| {
+    if (@typeInfo(T) != .@"union") return false;
+    for (reflect.unionFields(T)) |field| {
         if (field.type != void) return true;
     }
     return false;

--- a/src/formats/xml/deserializer.zig
+++ b/src/formats/xml/deserializer.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const scanner_mod = @import("scanner.zig");
 const core_deserialize = @import("../../core/deserialize.zig");
+const reflect = @import("../../reflect.zig");
 
 const Scanner = scanner_mod.Scanner;
 const Token = scanner_mod.Token;
@@ -95,7 +96,7 @@ pub const Deserializer = struct {
 
     pub fn deserializeEnum(self: *Deserializer, comptime T: type) Error!T {
         const text = try self.readTextContent();
-        inline for (@typeInfo(T).@"enum".fields) |field| {
+        inline for (reflect.enumFields(T)) |field| {
             if (std.mem.eql(u8, text, field.name))
                 return @enumFromInt(field.value);
         }
@@ -103,12 +104,12 @@ pub const Deserializer = struct {
     }
 
     pub fn deserializeUnion(self: *Deserializer, comptime T: type, allocator: Allocator) Error!T {
-        const info = @typeInfo(T).@"union";
+        const fields = reflect.unionFields(T);
         // External tagging: element name is the variant discriminator.
         const tok = try self.scanner.next();
         switch (tok) {
             .element_open => |name| {
-                inline for (info.fields) |field| {
+                inline for (fields) |field| {
                     if (std.mem.eql(u8, name, field.name)) {
                         if (field.type == void) {
                             // Consume until closing tag.
@@ -124,7 +125,7 @@ pub const Deserializer = struct {
                 return error.UnexpectedToken;
             },
             .self_closing => |name| {
-                inline for (info.fields) |field| {
+                inline for (fields) |field| {
                     if (field.type == void and std.mem.eql(u8, name, field.name)) {
                         return @unionInit(T, field.name, {});
                     }
@@ -133,7 +134,7 @@ pub const Deserializer = struct {
             },
             .text => |text| {
                 // Try to match as a void variant by name.
-                inline for (info.fields) |field| {
+                inline for (fields) |field| {
                     if (field.type == void and std.mem.eql(u8, text, field.name)) {
                         return @unionInit(T, field.name, {});
                     }
@@ -406,7 +407,7 @@ fn deserializeFromText(comptime T: type, text: []const u8, allocator: Allocator,
         }
         return Scanner.unescapeEntities(allocator, text) catch error.MalformedXml;
     } else if (k == .@"enum") {
-        inline for (@typeInfo(T).@"enum".fields) |field| {
+        inline for (reflect.enumFields(T)) |field| {
             if (std.mem.eql(u8, text, field.name))
                 return @enumFromInt(field.value);
         }

--- a/src/formats/xml/mod.zig
+++ b/src/formats/xml/mod.zig
@@ -13,6 +13,7 @@ const core_serialize = @import("../../core/serialize.zig");
 const core_deserialize = @import("../../core/deserialize.zig");
 const kind_mod = @import("../../core/kind.zig");
 const xml_writer = @import("writer.zig");
+const reflect = @import("../../reflect.zig");
 const opt = @import("../../core/options.zig");
 
 pub const Serializer = serializer_mod.Serializer;
@@ -153,14 +154,14 @@ fn writeStructElement(
     comptime root_name: []const u8,
     comptime schema: anytype,
 ) !void {
-    const info = @typeInfo(T).@"struct";
+    const fields = reflect.structFields(T);
 
     // Opening tag with attributes.
     writer.writeByte('<') catch return error.WriteFailed;
     writer.writeAll(root_name) catch return error.WriteFailed;
 
     // Attributes: fields marked with xml_attribute.
-    inline for (info.fields) |field| {
+    inline for (fields) |field| {
         if (comptime opt.shouldSkipFieldSchema(T, field.name, .serialize, schema)) continue;
         if (comptime isXmlAttribute(T, field.name, schema)) {
             writer.writeByte(' ') catch return error.WriteFailed;
@@ -181,7 +182,7 @@ fn writeStructElement(
     if (opts.pretty) ser.depth = 1;
     var ss = try ser.beginStruct();
 
-    inline for (info.fields) |field| {
+    inline for (fields) |field| {
         if (comptime opt.shouldSkipFieldSchema(T, field.name, .serialize, schema)) continue;
         if (comptime isXmlAttribute(T, field.name, schema)) continue;
 
@@ -189,8 +190,7 @@ fn writeStructElement(
             if (@typeInfo(field.type) != .@"struct")
                 @compileError("Flatten requires a struct type, got " ++ @typeName(field.type));
             const nested = @field(value, field.name);
-            const nested_info = @typeInfo(field.type).@"struct";
-            inline for (nested_info.fields) |sf| {
+            inline for (reflect.structFields(field.type)) |sf| {
                 const nested_wire = comptime opt.wireFieldNameForDir(field.type, sf.name, {}, .serialize);
                 try ss.serializeField(nested_wire, @field(nested, sf.name));
             }
@@ -276,7 +276,7 @@ fn isXmlAttribute(comptime T: type, comptime field_name: []const u8, comptime sc
     if (S != void) {
         if (@hasField(S, "xml_attribute")) {
             const attrs = schema.xml_attribute;
-            const attr_fields = @typeInfo(@TypeOf(attrs)).@"struct".fields;
+            const attr_fields = reflect.structFields(@TypeOf(attrs));
             inline for (attr_fields) |f| {
                 const val = @field(attrs, f.name);
                 const tag_name = @tagName(val);
@@ -290,7 +290,7 @@ fn isXmlAttribute(comptime T: type, comptime field_name: []const u8, comptime sc
     const SerdeTy = @TypeOf(serde);
     if (!@hasField(SerdeTy, "xml_attribute") and !@hasDecl(SerdeTy, "xml_attribute")) return false;
     const attrs = serde.xml_attribute;
-    const attr_fields = @typeInfo(@TypeOf(attrs)).@"struct".fields;
+    const attr_fields = reflect.structFields(@TypeOf(attrs));
     inline for (attr_fields) |f| {
         const val = @field(attrs, f.name);
         const tag_name = @tagName(val);
@@ -351,9 +351,8 @@ fn xmlDeserialize(
 }
 
 fn initStructDefaults(comptime T: type, comptime schema: anytype) !T {
-    const info = @typeInfo(T).@"struct";
     var result: T = undefined;
-    inline for (info.fields) |field| {
+    inline for (reflect.structFields(T)) |field| {
         if (comptime field.defaultValue()) |dv| {
             @field(result, field.name) = dv;
         } else if (comptime opt.hasSerdeDefaultSchema(T, field.name, schema)) {

--- a/src/formats/yaml/deserializer.zig
+++ b/src/formats/yaml/deserializer.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const compat = @import("compat");
 const parser_mod = @import("parser.zig");
 const core_deserialize = @import("../../core/deserialize.zig");
+const reflect = @import("../../reflect.zig");
 
 const Allocator = std.mem.Allocator;
 const Value = parser_mod.Value;
@@ -67,7 +68,7 @@ pub const Deserializer = struct {
             return compat.intToEnum(T, int_val) orelse return error.UnexpectedToken;
         }
         if (self.value.* != .string) return error.WrongType;
-        inline for (@typeInfo(T).@"enum".fields) |field| {
+        inline for (reflect.enumFields(T)) |field| {
             if (std.mem.eql(u8, self.value.string, field.name))
                 return @enumFromInt(field.value);
         }
@@ -201,7 +202,7 @@ fn deserializeValue(comptime T: type, val: *const Value, allocator: Allocator) D
                 return compat.intToEnum(T, int_val) orelse return error.UnexpectedToken;
             }
             if (val.* != .string) return error.WrongType;
-            inline for (@typeInfo(T).@"enum".fields) |field| {
+            inline for (reflect.enumFields(T)) |field| {
                 if (std.mem.eql(u8, val.string, field.name))
                     return @enumFromInt(field.value);
             }
@@ -258,11 +259,11 @@ fn deserializeValue(comptime T: type, val: *const Value, allocator: Allocator) D
 }
 
 fn deserializeUnionFromValue(val: *const Value, comptime T: type, allocator: Allocator) DeserializeError!T {
-    const info = @typeInfo(T).@"union";
+    const fields = reflect.unionFields(T);
 
     // Void variants from string.
     if (val.* == .string) {
-        inline for (info.fields) |field| {
+        inline for (fields) |field| {
             if (field.type == void and std.mem.eql(u8, val.string, field.name)) {
                 return @unionInit(T, field.name, {});
             }
@@ -277,7 +278,7 @@ fn deserializeUnionFromValue(val: *const Value, comptime T: type, allocator: All
         const entry = it.next().?;
         const variant_name = entry.key_ptr.*;
 
-        inline for (info.fields) |field| {
+        inline for (fields) |field| {
             if (std.mem.eql(u8, variant_name, field.name)) {
                 if (field.type == void) {
                     return @unionInit(T, field.name, {});
@@ -335,7 +336,7 @@ const ValueDeserializer = struct {
 
     pub fn deserializeEnum(self: *ValueDeserializer, comptime T: type) Error!T {
         if (self.val.* != .string) return error.WrongType;
-        inline for (@typeInfo(T).@"enum".fields) |field| {
+        inline for (reflect.enumFields(T)) |field| {
             if (std.mem.eql(u8, self.val.string, field.name))
                 return @enumFromInt(field.value);
         }

--- a/src/formats/yaml/serializer.zig
+++ b/src/formats/yaml/serializer.zig
@@ -3,6 +3,7 @@ const compat = @import("compat");
 const core_serialize = @import("../../core/serialize.zig");
 const kind_mod = @import("../../core/kind.zig");
 const options = @import("../../core/options.zig");
+const reflect = @import("../../reflect.zig");
 
 pub const SerializeError = error{ OutOfMemory, WriteFailed };
 
@@ -352,9 +353,8 @@ fn nullReprString(repr: Options.NullRepr) []const u8 {
 }
 
 fn unionHasPayload(comptime T: type) bool {
-    const info = @typeInfo(T);
-    if (info != .@"union") return false;
-    for (info.@"union".fields) |field| {
+    if (@typeInfo(T) != .@"union") return false;
+    for (reflect.unionFields(T)) |field| {
         if (field.type != void) return true;
     }
     return false;

--- a/src/formats/zon/deserializer.zig
+++ b/src/formats/zon/deserializer.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const core_deserialize = @import("../../core/deserialize.zig");
+const reflect = @import("../../reflect.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -117,7 +118,7 @@ pub const Deserializer = struct {
             self.pos += 1;
             const name = self.readIdentifier();
             if (name.len == 0) return error.UnexpectedToken;
-            inline for (@typeInfo(T).@"enum".fields) |field| {
+            inline for (reflect.enumFields(T)) |field| {
                 if (std.mem.eql(u8, name, field.name))
                     return @enumFromInt(field.value);
             }
@@ -129,7 +130,7 @@ pub const Deserializer = struct {
             self.pos += 1;
             const raw = self.readUntil('"') orelse return error.UnexpectedEof;
             self.pos += 1; // skip closing quote
-            inline for (@typeInfo(T).@"enum".fields) |field| {
+            inline for (reflect.enumFields(T)) |field| {
                 if (std.mem.eql(u8, raw, field.name))
                     return @enumFromInt(field.value);
             }

--- a/src/reflect.zig
+++ b/src/reflect.zig
@@ -1,0 +1,169 @@
+const std = @import("std");
+
+pub const StructField = struct {
+    name: [:0]const u8,
+    type: type,
+    default_value_ptr: ?*const anyopaque,
+    is_comptime: bool,
+
+    /// Returns `null` if the field has no default value.
+    pub inline fn defaultValue(comptime sf: StructField) ?sf.type {
+        const dp: *const sf.type = @ptrCast(@alignCast(sf.default_value_ptr orelse return null));
+        return dp.*;
+    }
+};
+
+pub const EnumField = struct {
+    name: [:0]const u8,
+    value: comptime_int,
+};
+
+pub const UnionField = struct {
+    name: [:0]const u8,
+    type: type,
+};
+
+const soa = !@hasField(std.builtin.Type.Struct, "fields");
+
+pub inline fn structFields(comptime T: type) []const if (soa) StructField else std.builtin.Type.StructField {
+    const si = @typeInfo(T).@"struct";
+    comptime if (!soa) return si.fields;
+
+    comptime var out: []const StructField = &.{};
+
+    inline for (si.field_names, si.field_types, si.field_attrs) |fnam, ft, fa| {
+        out = out ++ &[_]StructField{
+            StructField{
+                .name = fnam,
+                .default_value_ptr = fa.default_value_ptr,
+                .is_comptime = fa.@"comptime",
+                .type = ft,
+            },
+        };
+    }
+
+    return out;
+}
+
+pub inline fn enumFields(comptime T: type) []const if (soa) EnumField else std.builtin.Type.EnumField {
+    const ei = @typeInfo(T).@"enum";
+    comptime if (!soa) return ei.fields;
+
+    comptime var out: []const EnumField = &.{};
+
+    inline for (ei.field_names, ei.field_values) |fnam, fv| {
+        out = out ++ &[_]EnumField{.{ .name = fnam, .value = fv }};
+    }
+
+    return out;
+}
+
+pub inline fn unionFields(comptime T: type) []const if (soa) UnionField else std.builtin.Type.UnionField {
+    const ui = @typeInfo(T).@"union";
+    comptime if (!soa) return ui.fields;
+
+    comptime var out: []const UnionField = &.{};
+
+    inline for (ui.field_names, ui.field_types) |fnam, ft| {
+        out = out ++ &[_]UnionField{.{ .name = fnam, .type = ft }};
+    }
+
+    return out;
+}
+
+const testing = std.testing;
+
+test "structFields" {
+    const S = struct {
+        name: []const u8,
+        address: *anyopaque,
+    };
+
+    const fields = structFields(S);
+
+    try testing.expect(fields.len == 2);
+    try testing.expectEqualStrings("name", fields[0].name);
+    try testing.expectEqualStrings("address", fields[1].name);
+    try testing.expect(fields[0].type == []const u8);
+}
+
+test "structFields: default values" {
+    const S = struct { a: u32, b: []const u8 = "hi", c: ?f64 = null };
+    const fields = comptime structFields(S);
+
+    try testing.expect(comptime fields[0].defaultValue() == null);
+    try testing.expectEqualStrings("hi", comptime fields[1].defaultValue().?);
+    try testing.expect(comptime fields[2].defaultValue().? == null);
+}
+
+test "structFields: tuple, empty struct, anon literal" {
+    const tuple = comptime structFields(struct { i32, bool });
+    try testing.expect(tuple.len == 2);
+    try testing.expect(tuple[1].type == bool);
+
+    try testing.expect(comptime structFields(struct {}).len == 0);
+
+    const attrs = .{ .alpha = @as(u8, 1), .beta = true };
+    const anon = comptime structFields(@TypeOf(attrs));
+    try testing.expectEqualStrings("alpha", anon[0].name);
+    try testing.expectEqual(true, @field(attrs, anon[1].name));
+}
+
+test "enumFields: explicit values" {
+    const E = enum(u8) { red = 3, green = 7, blue = 9 };
+    const fields = comptime enumFields(E);
+
+    try testing.expect(fields.len == 3);
+    try testing.expectEqualStrings("green", fields[1].name);
+    try testing.expect(fields[1].value == 7);
+    try testing.expectEqual(E.blue, @as(E, @enumFromInt(fields[2].value)));
+}
+
+test "unionFields: payload and void variants" {
+    const U = union(enum) { num: i64, nothing: void, nested: struct { w: f64 } };
+    const fields = comptime unionFields(U);
+
+    try testing.expect(fields.len == 3);
+    try testing.expect(fields[0].type == i64);
+    try testing.expect(fields[1].type == void);
+    try testing.expectEqualStrings("nested", fields[2].name);
+}
+
+test "inline for mirrors serializer call sites" {
+    const S = struct { x: i32 = 5, y: i32 = 6 };
+    var s: S = undefined;
+    inline for (structFields(S)) |field| {
+        if (comptime field.defaultValue()) |dv| @field(s, field.name) = dv;
+    }
+    try testing.expectEqual(5, s.x);
+    try testing.expectEqual(6, s.y);
+}
+
+test "runtime key matched against comptime field names" {
+    const E = enum { alpha, beta };
+    const key: []const u8 = "beta";
+    var found: ?E = null;
+    inline for (enumFields(E)) |field| {
+        if (std.mem.eql(u8, key, field.name)) found = @enumFromInt(field.value);
+    }
+    try testing.expectEqual(E.beta, found.?);
+}
+
+test "non-inline comptime for over fields" {
+    const S = struct { a: u8, bb: u8, ccc: u8 };
+    const total = comptime blk: {
+        var n: usize = 0;
+        for (structFields(S)) |field| n += field.name.len;
+        break :blk n;
+    };
+    try testing.expectEqual(6, total);
+}
+
+test "field count is usable as a comptime size" {
+    const S = struct { a: u8, b: u8, c: u8 };
+    const BitSet = std.StaticBitSet(structFields(S).len);
+    var seen = if (@hasDecl(BitSet, "empty")) BitSet.empty else BitSet.initEmpty();
+    seen.set(1);
+    try testing.expect(seen.capacity() == 3);
+    try testing.expect(seen.isSet(1));
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -106,4 +106,5 @@ test {
     _ = @import("formats/toon/parser.zig");
     _ = @import("formats/toon/serializer.zig");
     _ = @import("formats/toon/deserializer.zig");
+    _ = @import("reflect.zig");
 }


### PR DESCRIPTION
The main changes I made:

* Wrote a compatibility shim `reflect.zig` (replaces most usage of `@typeInfo(T).@"struct".fields` and friends with `reflect.structFields()`).

  This is because of the changes from an array of structs -> struct of arrays for struct, union, and enum fields.
  
  Tested and confirmed it working on 0.15.2, 0.16.0, and master. 
* Use build options for benchmarking arguments, since newer build system versions got rid of `b.args`. This is backwards compatible. I also updated CI to reflect this.
* CI now also benchmarks master, since I couldn't see why this wasn't done

Anyway, CI passes on my fork, barring the GitHub pages stuff since I had that disabled on my end.

These changes should make it super easy to migrate to 0.17.0 when tagged.

Thanks anyway, hope the diff isn't too large, but there were a lot of places that wanted updating to get this working.