### PR TITLE
perf(json): improve string deserialization performance

### DIFF
--- a/bench/main.zig
+++ b/bench/main.zig
@@ -91,6 +91,7 @@ const enum_json = "\"green\"";
 const borrowed_json = "{\"id\":99,\"title\":\"zero copy\",\"body\":\"plain string without escapes\"}";
 const long_plain_json = makePlainStringJson(16 * 1024);
 const long_escaped_json = makeEscapedStringJson(8 * 1024);
+const long_sparse_escaped_json = makeSparseEscapedStringJson(128, 128);
 
 fn makePlainStringJson(comptime length: usize) [11 + length]u8 {
     var input: [11 + length]u8 = undefined;
@@ -108,6 +109,26 @@ fn makeEscapedStringJson(comptime escapes: usize) [11 + escapes * 2]u8 {
     for (0..escapes) |index| {
         input[9 + index * 2] = '\\';
         input[10 + index * 2] = 'n';
+    }
+    input[input.len - 2] = '"';
+    input[input.len - 1] = '}';
+    return input;
+}
+
+/// Prose-shaped input: long plain runs punctuated by the occasional escape,
+/// which is what real documents look like. The all-plain and all-escape cases
+/// above are the two extremes and behave differently from this one.
+fn makeSparseEscapedStringJson(comptime runs: usize, comptime run_length: usize) [11 + runs * (run_length + 2)]u8 {
+    @setEvalBranchQuota(runs * (run_length + 2) + 1_000);
+    var input: [11 + runs * (run_length + 2)]u8 = undefined;
+    @memcpy(input[0..9], "{\"text\":\"");
+    var at: usize = 9;
+    for (0..runs) |_| {
+        @memset(input[at .. at + run_length], 'a');
+        at += run_length;
+        input[at] = '\\';
+        input[at + 1] = 'n';
+        at += 2;
     }
     input[input.len - 2] = '"';
     input[input.len - 1] = '}';
@@ -533,6 +554,14 @@ fn opJsonLongEscapedDeserialize(allocator: Allocator) !usize {
     return long_escaped_json.len;
 }
 
+fn opJsonLongSparseEscapedDeserialize(allocator: Allocator) !usize {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const value = try serde.json.fromSlice(StringDocument, arena.allocator(), &long_sparse_escaped_json);
+    std.mem.doNotOptimizeAway(value.text.ptr);
+    return long_sparse_escaped_json.len;
+}
+
 fn opMsgpackSerialize(allocator: Allocator) !usize {
     const out = try serde.msgpack.toSlice(allocator, nested_value);
     defer allocator.free(out);
@@ -637,6 +666,7 @@ const benchmarks = [_]Benchmark{
     .{ .id = "json.long_plain.deserialize.serde.warm", .format = "json", .case_name = "long_plain", .operation = "deserialize", .implementation = "serde", .mode = .warm, .input_bytes = long_plain_json.len, .key_case = true, .run = opJsonLongPlainDeserialize },
     .{ .id = "json.long_plain_borrowed.deserialize.serde.warm", .format = "json", .case_name = "long_plain_borrowed", .operation = "deserialize", .implementation = "serde", .mode = .warm, .input_bytes = long_plain_json.len, .key_case = true, .run = opJsonLongPlainBorrowedDeserialize },
     .{ .id = "json.long_escaped.deserialize.serde.warm", .format = "json", .case_name = "long_escaped", .operation = "deserialize", .implementation = "serde", .mode = .warm, .input_bytes = long_escaped_json.len, .key_case = true, .run = opJsonLongEscapedDeserialize },
+    .{ .id = "json.long_sparse_escaped.deserialize.serde.warm", .format = "json", .case_name = "long_sparse_escaped", .operation = "deserialize", .implementation = "serde", .mode = .warm, .input_bytes = long_sparse_escaped_json.len, .key_case = true, .run = opJsonLongSparseEscapedDeserialize },
 
     .{ .id = "msgpack.nested.serialize.serde.warm", .format = "msgpack", .case_name = "nested_struct", .operation = "serialize", .implementation = "serde", .mode = .warm, .input_bytes = nested_json.len, .key_case = true, .run = opMsgpackSerialize },
     .{ .id = "msgpack.nested.serialize.serde.cold", .format = "msgpack", .case_name = "nested_struct", .operation = "serialize", .implementation = "serde", .mode = .cold, .input_bytes = nested_json.len, .key_case = true, .run = opMsgpackSerialize },

--- a/bench/main.zig
+++ b/bench/main.zig
@@ -58,6 +58,10 @@ const Borrowed = struct {
     body: []const u8,
 };
 
+const StringDocument = struct {
+    text: []const u8,
+};
+
 const flat_value = Flat{ .id = 42, .name = "alice", .active = true, .score = 91.75 };
 const flat_json = "{\"id\":42,\"name\":\"alice\",\"active\":true,\"score\":91.75}";
 
@@ -85,6 +89,30 @@ const command_value = Command{ .write = .{ .key = "feature", .value = "bench" } 
 const command_json = "{\"write\":{\"key\":\"feature\",\"value\":\"bench\"}}";
 const enum_json = "\"green\"";
 const borrowed_json = "{\"id\":99,\"title\":\"zero copy\",\"body\":\"plain string without escapes\"}";
+const long_plain_json = makePlainStringJson(16 * 1024);
+const long_escaped_json = makeEscapedStringJson(8 * 1024);
+
+fn makePlainStringJson(comptime length: usize) [11 + length]u8 {
+    var input: [11 + length]u8 = undefined;
+    @memcpy(input[0..9], "{\"text\":\"");
+    @memset(input[9 .. 9 + length], 'a');
+    input[9 + length] = '"';
+    input[10 + length] = '}';
+    return input;
+}
+
+fn makeEscapedStringJson(comptime escapes: usize) [11 + escapes * 2]u8 {
+    @setEvalBranchQuota(escapes * 2 + 1_000);
+    var input: [11 + escapes * 2]u8 = undefined;
+    @memcpy(input[0..9], "{\"text\":\"");
+    for (0..escapes) |index| {
+        input[9 + index * 2] = '\\';
+        input[10 + index * 2] = 'n';
+    }
+    input[input.len - 2] = '"';
+    input[input.len - 1] = '}';
+    return input;
+}
 
 const large_csv =
     "id,name,department,salary,active\n" ++
@@ -481,6 +509,30 @@ fn opJsonBorrowedDeserialize(allocator: Allocator) !usize {
     return borrowed_json.len;
 }
 
+fn opJsonLongPlainDeserialize(allocator: Allocator) !usize {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const value = try serde.json.fromSlice(StringDocument, arena.allocator(), &long_plain_json);
+    std.mem.doNotOptimizeAway(value.text.ptr);
+    return long_plain_json.len;
+}
+
+fn opJsonLongPlainBorrowedDeserialize(allocator: Allocator) !usize {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const value = try serde.json.fromSliceBorrowed(StringDocument, arena.allocator(), &long_plain_json);
+    std.mem.doNotOptimizeAway(value.text.ptr);
+    return long_plain_json.len;
+}
+
+fn opJsonLongEscapedDeserialize(allocator: Allocator) !usize {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const value = try serde.json.fromSlice(StringDocument, arena.allocator(), &long_escaped_json);
+    std.mem.doNotOptimizeAway(value.text.ptr);
+    return long_escaped_json.len;
+}
+
 fn opMsgpackSerialize(allocator: Allocator) !usize {
     const out = try serde.msgpack.toSlice(allocator, nested_value);
     defer allocator.free(out);
@@ -582,6 +634,9 @@ const benchmarks = [_]Benchmark{
     .{ .id = "json.dynamic_value.roundtrip.serde.warm", .format = "json", .case_name = "dynamic_value", .operation = "roundtrip", .implementation = "serde", .mode = .warm, .input_bytes = nested_json.len, .run = opJsonDynamicValue },
     .{ .id = "json.borrowed_strings.deserialize.serde.warm", .format = "json", .case_name = "borrowed_strings", .operation = "deserialize", .implementation = "serde", .mode = .warm, .input_bytes = borrowed_json.len, .key_case = true, .run = opJsonBorrowedDeserialize },
     .{ .id = "json.borrowed_strings.deserialize.serde.cold", .format = "json", .case_name = "borrowed_strings", .operation = "deserialize", .implementation = "serde", .mode = .cold, .input_bytes = borrowed_json.len, .key_case = true, .run = opJsonBorrowedDeserialize },
+    .{ .id = "json.long_plain.deserialize.serde.warm", .format = "json", .case_name = "long_plain", .operation = "deserialize", .implementation = "serde", .mode = .warm, .input_bytes = long_plain_json.len, .key_case = true, .run = opJsonLongPlainDeserialize },
+    .{ .id = "json.long_plain_borrowed.deserialize.serde.warm", .format = "json", .case_name = "long_plain_borrowed", .operation = "deserialize", .implementation = "serde", .mode = .warm, .input_bytes = long_plain_json.len, .key_case = true, .run = opJsonLongPlainBorrowedDeserialize },
+    .{ .id = "json.long_escaped.deserialize.serde.warm", .format = "json", .case_name = "long_escaped", .operation = "deserialize", .implementation = "serde", .mode = .warm, .input_bytes = long_escaped_json.len, .key_case = true, .run = opJsonLongEscapedDeserialize },
 
     .{ .id = "msgpack.nested.serialize.serde.warm", .format = "msgpack", .case_name = "nested_struct", .operation = "serialize", .implementation = "serde", .mode = .warm, .input_bytes = nested_json.len, .key_case = true, .run = opMsgpackSerialize },
     .{ .id = "msgpack.nested.serialize.serde.cold", .format = "msgpack", .case_name = "nested_struct", .operation = "serialize", .implementation = "serde", .mode = .cold, .input_bytes = nested_json.len, .key_case = true, .run = opMsgpackSerialize },

--- a/src/formats/json/deserializer.zig
+++ b/src/formats/json/deserializer.zig
@@ -105,7 +105,7 @@ pub const Deserializer = struct {
         const tok = try self.scanner.next();
         switch (tok) {
             .string => |raw| {
-                if (!Scanner.stringHasEscapes(raw)) {
+                if (!self.scanner.last_string_has_escape) {
                     if (self.borrow_strings) return raw;
                     const copy = allocator.alloc(u8, raw.len) catch return error.OutOfMemory;
                     @memcpy(copy, raw);
@@ -128,7 +128,7 @@ pub const Deserializer = struct {
         const tok = try self.scanner.next();
         switch (tok) {
             .string => |raw| {
-                if (Scanner.stringHasEscapes(raw)) {
+                if (self.scanner.last_string_has_escape) {
                     return error.InvalidEscape;
                 }
                 return raw;
@@ -276,7 +276,7 @@ pub const MapAccess = struct {
         switch (key_tok) {
             .string => |raw| {
                 try self.scanner.expectColon();
-                if (Scanner.stringHasEscapes(raw)) {
+                if (self.scanner.last_string_has_escape) {
                     if (self.borrow_strings) return error.InvalidEscape;
                     return try unescapeString(allocator, raw);
                 }

--- a/src/formats/json/deserializer.zig
+++ b/src/formats/json/deserializer.zig
@@ -343,22 +343,24 @@ fn errorFromAny(err: anyerror) DeserializeError {
 fn unescapeString(allocator: Allocator, raw: []const u8) DeserializeError![]const u8 {
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
-    // Unescaping never grows the string, so raw.len is enough.
-    try out.ensureTotalCapacity(allocator, raw.len);
+    // Every escape shrinks: two-byte escapes yield one byte, \uXXXX yields at
+    // most three, and a surrogate pair yields four out of twelve. So raw.len is
+    // an upper bound on the result and the appends below need no capacity check.
+    out.ensureTotalCapacity(allocator, raw.len) catch return error.OutOfMemory;
     var i: usize = 0;
     while (i < raw.len) {
         if (raw[i] == '\\') {
             i += 1;
             if (i >= raw.len) return error.UnexpectedEof;
             switch (raw[i]) {
-                '"' => try appendByte(&out, allocator, '"'),
-                '\\' => try appendByte(&out, allocator, '\\'),
-                '/' => try appendByte(&out, allocator, '/'),
-                'n' => try appendByte(&out, allocator, '\n'),
-                'r' => try appendByte(&out, allocator, '\r'),
-                't' => try appendByte(&out, allocator, '\t'),
-                'b' => try appendByte(&out, allocator, 0x08),
-                'f' => try appendByte(&out, allocator, 0x0c),
+                '"' => out.appendAssumeCapacity('"'),
+                '\\' => out.appendAssumeCapacity('\\'),
+                '/' => out.appendAssumeCapacity('/'),
+                'n' => out.appendAssumeCapacity('\n'),
+                'r' => out.appendAssumeCapacity('\r'),
+                't' => out.appendAssumeCapacity('\t'),
+                'b' => out.appendAssumeCapacity(0x08),
+                'f' => out.appendAssumeCapacity(0x0c),
                 'u' => {
                     i += 1;
                     if (i + 4 > raw.len) return error.UnexpectedEof;
@@ -375,13 +377,13 @@ fn unescapeString(allocator: Allocator, raw: []const u8) DeserializeError![]cons
                         const full: u21 = 0x10000 + (@as(u21, cp - 0xD800) << 10) + (low - 0xDC00);
                         var buf: [4]u8 = undefined;
                         const len = std.unicode.utf8Encode(full, &buf) catch return error.InvalidUnicode;
-                        out.appendSlice(allocator, buf[0..len]) catch return error.OutOfMemory;
+                        out.appendSliceAssumeCapacity(buf[0..len]);
                     } else {
                         if (cp >= 0xDC00 and cp <= 0xDFFF) return error.InvalidUnicode;
                         const cp21: u21 = @intCast(cp);
                         var buf: [4]u8 = undefined;
                         const len = std.unicode.utf8Encode(cp21, &buf) catch return error.InvalidUnicode;
-                        out.appendSlice(allocator, buf[0..len]) catch return error.OutOfMemory;
+                        out.appendSliceAssumeCapacity(buf[0..len]);
                     }
                     continue;
                 },
@@ -389,15 +391,11 @@ fn unescapeString(allocator: Allocator, raw: []const u8) DeserializeError![]cons
             }
             i += 1;
         } else {
-            try appendByte(&out, allocator, raw[i]);
+            out.appendAssumeCapacity(raw[i]);
             i += 1;
         }
     }
     return out.toOwnedSlice(allocator) catch return error.OutOfMemory;
-}
-
-fn appendByte(list: *std.ArrayList(u8), allocator: Allocator, byte: u8) DeserializeError!void {
-    list.append(allocator, byte) catch return error.OutOfMemory;
 }
 
 fn parseHex4(hex: *const [4]u8) ?u16 {
@@ -529,6 +527,15 @@ test "deserialize surrogate pair" {
     const s = try d.deserializeString(testing.allocator);
     defer testing.allocator.free(s);
     try testing.expectEqualStrings("\u{1F600}", s);
+}
+
+test "unescape every form within the reserved capacity" {
+    // Each escape form shrinks, so the reserved raw.len must cover the result.
+    // Debug and ReleaseSafe trip an assert here if that bound ever stops holding.
+    var d = Deserializer.init("\"\\\"\\\\\\/\\n\\r\\t\\b\\f\\u0041\\u00e9\\u20ac\\uD83D\\uDE00plain\"");
+    const s = try d.deserializeString(testing.allocator);
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("\"\\/\n\r\t\x08\x0cA\u{e9}\u{20ac}\u{1F600}plain", s);
 }
 
 test "deserialize lone low surrogate is rejected" {

--- a/src/formats/json/deserializer.zig
+++ b/src/formats/json/deserializer.zig
@@ -343,6 +343,8 @@ fn errorFromAny(err: anyerror) DeserializeError {
 fn unescapeString(allocator: Allocator, raw: []const u8) DeserializeError![]const u8 {
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
+    // Unescaping never grows the string, so raw.len is enough.
+    try out.ensureTotalCapacity(allocator, raw.len);
     var i: usize = 0;
     while (i < raw.len) {
         if (raw[i] == '\\') {

--- a/src/formats/json/scanner.zig
+++ b/src/formats/json/scanner.zig
@@ -51,6 +51,8 @@ pub const Scanner = struct {
     depth: u32 = 0,
     /// Maximum allowed nesting depth. Default 256.
     max_depth: u32 = 256,
+    /// Whether the last string token contained escape sequences.
+    last_string_has_escape: bool = false,
 
     pub fn next(self: *Scanner) ScanError!Token {
         self.skipWhitespace();
@@ -92,9 +94,11 @@ pub const Scanner = struct {
     pub fn peek(self: *Scanner) ScanError!Token {
         const saved_pos = self.pos;
         const saved_depth = self.depth;
+        const saved_last_string_has_escape = self.last_string_has_escape;
         const tok = try self.next();
         self.pos = saved_pos;
         self.depth = saved_depth;
+        self.last_string_has_escape = saved_last_string_has_escape;
         return tok;
     }
 
@@ -178,15 +182,6 @@ pub const Scanner = struct {
         }
     }
 
-    /// Whether the string at `index` contains escape sequences.
-    /// Used to decide zero-copy vs allocated path.
-    pub fn stringHasEscapes(value: []const u8) bool {
-        for (value) |c| {
-            if (c == '\\') return true;
-        }
-        return false;
-    }
-
     // Internal scanning methods.
 
     fn scanString(self: *Scanner) ScanError![]const u8 {
@@ -194,6 +189,7 @@ pub const Scanner = struct {
         const input = self.input;
         var pos = self.pos + 1; // skip opening quote
         const start = pos;
+        var has_escape = false;
 
         // Fast path: skip plain runs in chunks of four.
         const table = if (self.allow_unescaped_control_chars)
@@ -216,9 +212,11 @@ pub const Scanner = struct {
             if (c == '"') {
                 const result = input[start..pos];
                 self.pos = pos + 1; // skip closing quote
+                self.last_string_has_escape = has_escape;
                 return result;
             }
             if (c == '\\') {
+                has_escape = true;
                 pos += 1; // skip backslash
                 if (pos >= input.len) return error.UnexpectedEof;
                 const esc = input[pos];
@@ -334,7 +332,25 @@ test "scan string with escapes" {
     var s = Scanner{ .input = "\"hello\\nworld\"" };
     const tok = try s.next();
     try testing.expectEqualStrings("hello\\nworld", tok.string);
-    try testing.expect(Scanner.stringHasEscapes(tok.string));
+    try testing.expect(s.last_string_has_escape);
+}
+
+test "scan string without escapes" {
+    var s = Scanner{ .input = "\"hello\"" };
+    const tok = try s.next();
+    try testing.expectEqualStrings("hello", tok.string);
+    try testing.expect(!s.last_string_has_escape);
+}
+
+test "peek restores escape flag" {
+    var s = Scanner{ .input = "\"c\" \"a\\nb\"" };
+    _ = try s.next();
+    try testing.expect(!s.last_string_has_escape);
+    _ = try s.peek();
+    try testing.expect(!s.last_string_has_escape);
+    const tok = try s.next();
+    try testing.expectEqualStrings("a\\nb", tok.string);
+    try testing.expect(s.last_string_has_escape);
 }
 
 test "scan number formats" {

--- a/src/formats/json/scanner.zig
+++ b/src/formats/json/scanner.zig
@@ -1,5 +1,24 @@
 const std = @import("std");
 
+// String scan classes: 1 means "stop the fast run and handle byte by byte".
+// The default table flags `"`, `\`, and control characters; the relaxed one
+// leaves controls alone (allow_unescaped_control_chars).
+const string_char_table = blk: {
+    var table: [256]u8 = undefined;
+    for (&table, 0..) |*entry, byte| {
+        entry.* = if (byte < 0x20 or byte == '"' or byte == '\\') 1 else 0;
+    }
+    break :blk table;
+};
+
+const string_char_table_relaxed = blk: {
+    var table: [256]u8 = undefined;
+    for (&table, 0..) |*entry, byte| {
+        entry.* = if (byte == '"' or byte == '\\') 1 else 0;
+    }
+    break :blk table;
+};
+
 pub const Token = union(enum) {
     object_begin,
     object_end,
@@ -172,33 +191,51 @@ pub const Scanner = struct {
 
     fn scanString(self: *Scanner) ScanError![]const u8 {
         std.debug.assert(self.input[self.pos] == '"');
-        self.pos += 1; // skip opening quote
-        const start = self.pos;
-        while (self.pos < self.input.len) {
-            const c = self.input[self.pos];
+        const input = self.input;
+        var pos = self.pos + 1; // skip opening quote
+        const start = pos;
+
+        // Fast path: skip plain runs in chunks of four.
+        const table = if (self.allow_unescaped_control_chars)
+            &string_char_table_relaxed
+        else
+            &string_char_table;
+
+        while (pos + 4 <= input.len) {
+            const a = input[pos];
+            const b = input[pos + 1];
+            const c = input[pos + 2];
+            const d = input[pos + 3];
+            if ((table[a] | table[b] | table[c] | table[d]) == 0) {
+                pos += 4;
+            } else break;
+        }
+
+        while (pos < input.len) {
+            const c = input[pos];
             if (c == '"') {
-                const result = self.input[start..self.pos];
-                self.pos += 1; // skip closing quote
+                const result = input[start..pos];
+                self.pos = pos + 1; // skip closing quote
                 return result;
             }
             if (c == '\\') {
-                self.pos += 1; // skip backslash
-                if (self.pos >= self.input.len) return error.UnexpectedEof;
-                const esc = self.input[self.pos];
+                pos += 1; // skip backslash
+                if (pos >= input.len) return error.UnexpectedEof;
+                const esc = input[pos];
                 switch (esc) {
                     '"', '\\', '/', 'b', 'f', 'n', 'r', 't' => {
-                        self.pos += 1;
+                        pos += 1;
                     },
                     'u' => {
-                        self.pos += 1;
-                        if (self.pos + 4 > self.input.len) return error.UnexpectedEof;
-                        self.pos += 4;
+                        pos += 1;
+                        if (pos + 4 > input.len) return error.UnexpectedEof;
+                        pos += 4;
                     },
                     else => return error.InvalidEscape,
                 }
             } else {
                 if (c < 0x20 and !self.allow_unescaped_control_chars) return error.InvalidControlCharacter;
-                self.pos += 1;
+                pos += 1;
             }
         }
         return error.UnexpectedEof;

--- a/src/formats/json/scanner.zig
+++ b/src/formats/json/scanner.zig
@@ -51,7 +51,9 @@ pub const Scanner = struct {
     depth: u32 = 0,
     /// Maximum allowed nesting depth. Default 256.
     max_depth: u32 = 256,
-    /// Whether the last string token contained escape sequences.
+    /// Whether the last string token contained escape sequences. Only valid
+    /// immediately after `next()` returned a `.string`; any later scan,
+    /// including one made by `skipValue`, overwrites it. `peek()` restores it.
     last_string_has_escape: bool = false,
 
     pub fn next(self: *Scanner) ScanError!Token {

--- a/src/formats/json/scanner.zig
+++ b/src/formats/json/scanner.zig
@@ -190,6 +190,10 @@ pub const Scanner = struct {
         var pos = self.pos + 1; // skip opening quote
         const start = pos;
         var has_escape = false;
+        // The loops below track the cursor locally, so publish it on the error
+        // paths too: callers reading `pos` after a failure expect it to point at
+        // the offending byte, not back at the opening quote.
+        errdefer self.pos = pos;
 
         // Fast path: skip plain runs in chunks of four.
         const table = if (self.allow_unescaped_control_chars)
@@ -340,6 +344,20 @@ test "scan string without escapes" {
     const tok = try s.next();
     try testing.expectEqualStrings("hello", tok.string);
     try testing.expect(!s.last_string_has_escape);
+}
+
+test "string scan errors leave pos at the offending byte" {
+    var eof = Scanner{ .input = "\"abcdefgh" };
+    try testing.expectError(error.UnexpectedEof, eof.next());
+    try testing.expectEqual(@as(usize, 9), eof.pos);
+
+    var bad_escape = Scanner{ .input = "\"abcdefgh\\q\"" };
+    try testing.expectError(error.InvalidEscape, bad_escape.next());
+    try testing.expectEqual(@as(usize, 10), bad_escape.pos);
+
+    var control = Scanner{ .input = "\"abcdefgh\x01\"" };
+    try testing.expectError(error.InvalidControlCharacter, control.next());
+    try testing.expectEqual(@as(usize, 9), control.pos);
 }
 
 test "peek restores escape flag" {


### PR DESCRIPTION
I found serde.zig while looking at Zig serialization libraries and liked the general design, especially the idea of keeping the serde-style model separate from each format.

While trying the JSON benchmarks, I started looking at the reader hot paths to see if there were some simple things that could be improved without changing the overall model.

I also looked at simdjson and yyjson for ideas. simdjson is very fast, but its staged SIMD design felt too big for this kind of change. yyjson had a few smaller ideas that fit serde.zig better.

I first tried these changes in a small side project, [jsonz](https://github.com/KercyDing/jsonz), so I could experiment without making a bunch of changes in serde.zig itself. A few of the string changes worked well and were small enough to bring back here.

This PR only changes JSON string deserialization:

- scan plain string bytes four at a time
- remember if escapes were found while scanning, so we do not scan the string again
- reserve the unescape buffer early instead of growing it several times

I also added a few long-string benchmarks so these cases are easier to measure.

On my x86_64 Linux machine with Zig 0.17-dev, using 15 samples per result:

| Case | Before | After | Result |
| :---: | :---: | :---: | :---: |
| long plain owned string | 22.31 µs | 14.14 µs | ~1.58× faster |
| long plain borrowed string | 10.12 µs | 2.45 µs | ~4.13× faster |
| long escaped string | 41.55 µs | 24.39 µs | ~1.70× faster |
| long escaped string allocations | 3 alloc/op | 1 alloc/op | 3 → 1 |

The escaped-string preallocation uses a bit more memory up front, but avoids extra allocations and is faster.

Validation:

```sh
zig build test
zig build bench -Dbench-filter=long
```

I put the benchmark commit before the optimization commits on purpose, so each change can be compared with its parent directly.