### PR TITLE
perf(msgpack): improve container performance

### DIFF
--- a/src/formats/msgpack/deserializer.zig
+++ b/src/formats/msgpack/deserializer.zig
@@ -177,15 +177,23 @@ pub const Deserializer = struct {
         const tag = try self.readByte();
         const len = readArrayLen(tag, self) catch return error.WrongType;
 
-        var items: std.ArrayList(Child) = .empty;
-        errdefer items.deinit(allocator);
-
-        for (0..len) |_| {
-            const elem = try core_deserialize.deserialize(Child, allocator, self, .{});
-            items.append(allocator, elem) catch return error.OutOfMemory;
+        // MessagePack carries the exact array length, so allocate once instead
+        // of growing an ArrayList while decoding each element.
+        const items = allocator.alloc(Child, len) catch return error.OutOfMemory;
+        var initialized: usize = 0;
+        errdefer {
+            for (items[0..initialized]) |elem| {
+                core_deserialize.freeAllocated(Child, elem, allocator);
+            }
+            allocator.free(items);
         }
 
-        return items.toOwnedSlice(allocator) catch return error.OutOfMemory;
+        for (items) |*item| {
+            item.* = try core_deserialize.deserialize(Child, allocator, self, .{});
+            initialized += 1;
+        }
+
+        return items;
     }
 
     pub fn deserializeSeqAccess(self: *Deserializer) Error!SeqAccess {

--- a/src/formats/msgpack/deserializer.zig
+++ b/src/formats/msgpack/deserializer.zig
@@ -177,8 +177,10 @@ pub const Deserializer = struct {
         const tag = try self.readByte();
         const len = readArrayLen(tag, self) catch return error.WrongType;
 
-        // MessagePack carries the exact array length, so allocate once instead
-        // of growing an ArrayList while decoding each element.
+        // MessagePack provides the exact array length, so validate it before
+        // allocating and fill the final slice directly instead of growing an
+        // ArrayList while decoding each element.
+        if (len > self.input.len - self.pos) return error.UnexpectedEof;
         const items = allocator.alloc(Child, len) catch return error.OutOfMemory;
         var initialized: usize = 0;
         errdefer {

--- a/src/formats/msgpack/mod.zig
+++ b/src/formats/msgpack/mod.zig
@@ -16,7 +16,7 @@ pub const Deserializer = deserializer_mod.Deserializer;
 /// Serialize a value to a MessagePack byte slice. Caller owns the returned memory.
 pub fn toSlice(allocator: std.mem.Allocator, value: anytype) ![]u8 {
     var aw: compat.Io.Writer.Allocating = .init(allocator);
-    var ser = Serializer.init(&aw.writer, allocator);
+    var ser = Serializer.initBackpatch(&aw.writer, allocator);
     try core_serialize.serialize(@TypeOf(value), value, &ser, .{});
     return aw.toOwnedSlice();
 }
@@ -41,7 +41,7 @@ pub fn toWriter(allocator: std.mem.Allocator, writer: *compat.Io.Writer, value: 
 /// Serialize a value to a MessagePack byte slice with an external schema.
 pub fn toSliceSchema(allocator: std.mem.Allocator, value: anytype, comptime schema: anytype) ![]u8 {
     var aw: compat.Io.Writer.Allocating = .init(allocator);
-    var ser = Serializer.init(&aw.writer, allocator);
+    var ser = Serializer.initBackpatch(&aw.writer, allocator);
     try core_serialize.serializeSchema(@TypeOf(value), value, &ser, schema, .{});
     return aw.toOwnedSlice();
 }

--- a/src/formats/msgpack/mod.zig
+++ b/src/formats/msgpack/mod.zig
@@ -15,10 +15,7 @@ pub const Deserializer = deserializer_mod.Deserializer;
 
 /// Serialize a value to a MessagePack byte slice. Caller owns the returned memory.
 pub fn toSlice(allocator: std.mem.Allocator, value: anytype) ![]u8 {
-    var aw: compat.Io.Writer.Allocating = .init(allocator);
-    var ser = Serializer.initBackpatch(&aw.writer, allocator);
-    try core_serialize.serialize(@TypeOf(value), value, &ser, .{});
-    return aw.toOwnedSlice();
+    return serializer_mod.toSlice(allocator, value);
 }
 
 /// Serialize a value to a null-terminated MessagePack byte slice. Caller owns the returned memory.
@@ -40,10 +37,7 @@ pub fn toWriter(allocator: std.mem.Allocator, writer: *compat.Io.Writer, value: 
 
 /// Serialize a value to a MessagePack byte slice with an external schema.
 pub fn toSliceSchema(allocator: std.mem.Allocator, value: anytype, comptime schema: anytype) ![]u8 {
-    var aw: compat.Io.Writer.Allocating = .init(allocator);
-    var ser = Serializer.initBackpatch(&aw.writer, allocator);
-    try core_serialize.serializeSchema(@TypeOf(value), value, &ser, schema, .{});
-    return aw.toOwnedSlice();
+    return serializer_mod.toSliceSchema(allocator, value, schema);
 }
 
 /// Serialize a value to a writer in MessagePack format with an external schema.
@@ -258,6 +252,27 @@ test "roundtrip array" {
     defer testing.allocator.free(bytes);
     const val = try fromSlice([3]i32, testing.allocator, bytes);
     try testing.expectEqual([3]i32{ 10, 20, 30 }, val);
+}
+
+test "roundtrip nested containers" {
+    const Entry = struct {
+        name: []const u8,
+        values: []const i32,
+    };
+    const Document = struct {
+        entries: []const Entry,
+    };
+    const document = Document{ .entries = &.{
+        .{ .name = "first", .values = &.{ 1, 2, 3 } },
+        .{ .name = "second", .values = &.{ 4, 5 } },
+    } };
+
+    const bytes = try toSlice(testing.allocator, document);
+    defer testing.allocator.free(bytes);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const decoded = try fromSlice(Document, arena.allocator(), bytes);
+    try testing.expectEqualDeep(document, decoded);
 }
 
 test "roundtrip enum" {
@@ -783,6 +798,12 @@ test "roundtrip i128 within i64 range" {
 
 test "deserialize error: truncated input" {
     const result = fromSlice(i32, testing.allocator, &.{ 0xce, 0x12 });
+    try testing.expectError(error.UnexpectedEof, result);
+}
+
+test "deserialize error: oversized array length" {
+    const input = [_]u8{ 0xdd, 0xff, 0xff, 0xff, 0xff, 0x01 };
+    const result = fromSlice([]const i32, testing.allocator, &input);
     try testing.expectError(error.UnexpectedEof, result);
 }
 

--- a/src/formats/msgpack/serializer.zig
+++ b/src/formats/msgpack/serializer.zig
@@ -9,11 +9,16 @@ pub const SerializeError = error{ OutOfMemory, WriteFailed };
 pub const Serializer = struct {
     out: *compat.Io.Writer,
     allocator: Allocator,
+    backpatch_containers: bool = false,
 
     pub const Error = SerializeError;
 
     pub fn init(out: *compat.Io.Writer, allocator: Allocator) Serializer {
         return .{ .out = out, .allocator = allocator };
+    }
+
+    pub fn initBackpatch(out: *compat.Io.Writer, allocator: Allocator) Serializer {
+        return .{ .out = out, .allocator = allocator, .backpatch_containers = true };
     }
 
     pub fn serializeBool(self: *Serializer, value: bool) Error!void {
@@ -80,6 +85,11 @@ pub const Serializer = struct {
     }
 
     pub fn beginStruct(self: *Serializer) Error!StructSerializer {
+        if (self.backpatch_containers) {
+            const start = self.out.end;
+            self.out.writeAll(&.{ 0xdf, 0, 0, 0, 0 }) catch return error.WriteFailed;
+            return .{ .parent_out = self.out, .aw = undefined, .allocator = self.allocator, .field_count = 0, .backpatch = true, .start = start };
+        }
         return .{
             .parent_out = self.out,
             .aw = .init(self.allocator),
@@ -89,6 +99,11 @@ pub const Serializer = struct {
     }
 
     pub fn beginArray(self: *Serializer) Error!ArraySerializer {
+        if (self.backpatch_containers) {
+            const start = self.out.end;
+            self.out.writeAll(&.{ 0xdd, 0, 0, 0, 0 }) catch return error.WriteFailed;
+            return .{ .parent_out = self.out, .aw = undefined, .allocator = self.allocator, .elem_count = 0, .backpatch = true, .start = start };
+        }
         return .{
             .parent_out = self.out,
             .aw = .init(self.allocator),
@@ -106,24 +121,29 @@ pub const StructSerializer = struct {
     aw: compat.Io.Writer.Allocating,
     allocator: Allocator,
     field_count: u32,
+    backpatch: bool = false,
+    start: usize = 0,
 
     pub const Error = SerializeError;
 
     pub fn serializeField(self: *StructSerializer, comptime key: []const u8, value: anytype) Error!void {
-        var child = Serializer.init(&self.aw.writer, self.allocator);
+        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeString(key);
         try core_serialize.serialize(@TypeOf(value), value, &child, .{});
         self.field_count += 1;
     }
 
     pub fn serializeEntry(self: *StructSerializer, key: anytype, value: anytype) Error!void {
-        var child = Serializer.init(&self.aw.writer, self.allocator);
+        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
         try core_serialize.serialize(@TypeOf(key), key, &child, .{});
         try core_serialize.serialize(@TypeOf(value), value, &child, .{});
         self.field_count += 1;
     }
 
     pub fn end(self: *StructSerializer) Error!void {
+        if (self.backpatch) {
+            return finishDirect(self.parent_out, self.start, self.field_count, true);
+        }
         writeMapHeader(self.parent_out, self.field_count) catch {
             self.aw.deinit();
             return error.WriteFailed;
@@ -142,53 +162,60 @@ pub const ArraySerializer = struct {
     aw: compat.Io.Writer.Allocating,
     allocator: Allocator,
     elem_count: u32,
+    backpatch: bool = false,
+    start: usize = 0,
 
     pub const Error = SerializeError;
 
     pub fn serializeBool(self: *ArraySerializer, value: bool) Error!void {
-        var child = Serializer.init(&self.aw.writer, self.allocator);
+        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeBool(value);
         self.elem_count += 1;
     }
 
     pub fn serializeInt(self: *ArraySerializer, value: anytype) Error!void {
-        var child = Serializer.init(&self.aw.writer, self.allocator);
+        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeInt(value);
         self.elem_count += 1;
     }
 
     pub fn serializeFloat(self: *ArraySerializer, value: anytype) Error!void {
-        var child = Serializer.init(&self.aw.writer, self.allocator);
+        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeFloat(value);
         self.elem_count += 1;
     }
 
     pub fn serializeString(self: *ArraySerializer, value: []const u8) Error!void {
-        var child = Serializer.init(&self.aw.writer, self.allocator);
+        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeString(value);
         self.elem_count += 1;
     }
 
     pub fn serializeBytes(self: *ArraySerializer, value: []const u8) Error!void {
-        var child = Serializer.init(&self.aw.writer, self.allocator);
+        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeBytes(value);
         self.elem_count += 1;
     }
 
     pub fn serializeNull(self: *ArraySerializer) Error!void {
-        var child = Serializer.init(&self.aw.writer, self.allocator);
+        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeNull();
         self.elem_count += 1;
     }
 
     pub fn serializeVoid(self: *ArraySerializer) Error!void {
-        var child = Serializer.init(&self.aw.writer, self.allocator);
+        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeVoid();
         self.elem_count += 1;
     }
 
     pub fn beginStruct(self: *ArraySerializer) Error!StructSerializer {
         self.elem_count += 1;
+        if (self.backpatch) {
+            const start = self.parent_out.end;
+            self.parent_out.writeAll(&.{ 0xdf, 0, 0, 0, 0 }) catch return error.WriteFailed;
+            return .{ .parent_out = self.parent_out, .aw = undefined, .allocator = self.allocator, .field_count = 0, .backpatch = true, .start = start };
+        }
         return .{
             .parent_out = &self.aw.writer,
             .aw = .init(self.allocator),
@@ -199,6 +226,11 @@ pub const ArraySerializer = struct {
 
     pub fn beginArray(self: *ArraySerializer) Error!ArraySerializer {
         self.elem_count += 1;
+        if (self.backpatch) {
+            const start = self.parent_out.end;
+            self.parent_out.writeAll(&.{ 0xdd, 0, 0, 0, 0 }) catch return error.WriteFailed;
+            return .{ .parent_out = self.parent_out, .aw = undefined, .allocator = self.allocator, .elem_count = 0, .backpatch = true, .start = start };
+        }
         return .{
             .parent_out = &self.aw.writer,
             .aw = .init(self.allocator),
@@ -208,6 +240,9 @@ pub const ArraySerializer = struct {
     }
 
     pub fn end(self: *ArraySerializer) Error!void {
+        if (self.backpatch) {
+            return finishDirect(self.parent_out, self.start, self.elem_count, false);
+        }
         writeArrayHeader(self.parent_out, self.elem_count) catch {
             self.aw.deinit();
             return error.WriteFailed;
@@ -256,6 +291,45 @@ fn writeSint(out: *compat.Io.Writer, v: i64) !void {
     } else {
         try out.writeByte(0xd3);
         try out.writeAll(&toBE(u64, @bitCast(v)));
+    }
+}
+
+fn finishDirect(out: *compat.Io.Writer, start: usize, count: u32, map: bool) !void {
+    const header_len: usize = if (map)
+        if (count <= 15) 1 else if (count <= 0xffff) 3 else 5
+    else if (count <= 15) 1 else if (count <= 0xffff) 3 else 5;
+    const payload_start = start + 5;
+    const payload_len = out.end - payload_start;
+    const shift = 5 - header_len;
+    if (shift != 0) {
+        std.mem.copyForwards(u8, out.buffer[start + header_len ..][0..payload_len], out.buffer[payload_start..][0..payload_len]);
+        out.end -= shift;
+    }
+    const header = out.buffer[start..][0..header_len];
+    if (map) writeMapHeaderFixed(header, count) else writeArrayHeaderFixed(header, count);
+}
+
+fn writeMapHeaderFixed(out: []u8, count: u32) void {
+    if (count <= 15) {
+        out[0] = @intCast(0x80 | count);
+    } else if (count <= 0xffff) {
+        out[0] = 0xde;
+        std.mem.writeInt(u16, out[1..3], @intCast(count), .big);
+    } else {
+        out[0] = 0xdf;
+        std.mem.writeInt(u32, out[1..5], count, .big);
+    }
+}
+
+fn writeArrayHeaderFixed(out: []u8, count: u32) void {
+    if (count <= 15) {
+        out[0] = @intCast(0x90 | count);
+    } else if (count <= 0xffff) {
+        out[0] = 0xdc;
+        std.mem.writeInt(u16, out[1..3], @intCast(count), .big);
+    } else {
+        out[0] = 0xdd;
+        std.mem.writeInt(u32, out[1..5], count, .big);
     }
 }
 

--- a/src/formats/msgpack/serializer.zig
+++ b/src/formats/msgpack/serializer.zig
@@ -6,6 +6,22 @@ const Allocator = std.mem.Allocator;
 
 pub const SerializeError = error{ OutOfMemory, WriteFailed };
 
+pub fn toSlice(allocator: Allocator, value: anytype) ![]u8 {
+    var aw: compat.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
+    var serializer = Serializer.initBackpatch(&aw.writer, allocator);
+    try core_serialize.serialize(@TypeOf(value), value, &serializer, .{});
+    return aw.toOwnedSlice();
+}
+
+pub fn toSliceSchema(allocator: Allocator, value: anytype, comptime schema: anytype) ![]u8 {
+    var aw: compat.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
+    var serializer = Serializer.initBackpatch(&aw.writer, allocator);
+    try core_serialize.serializeSchema(@TypeOf(value), value, &serializer, schema, .{});
+    return aw.toOwnedSlice();
+}
+
 pub const Serializer = struct {
     out: *compat.Io.Writer,
     allocator: Allocator,
@@ -17,7 +33,7 @@ pub const Serializer = struct {
         return .{ .out = out, .allocator = allocator };
     }
 
-    pub fn initBackpatch(out: *compat.Io.Writer, allocator: Allocator) Serializer {
+    fn initBackpatch(out: *compat.Io.Writer, allocator: Allocator) Serializer {
         return .{ .out = out, .allocator = allocator, .backpatch_containers = true };
     }
 
@@ -142,7 +158,7 @@ pub const StructSerializer = struct {
 
     pub fn end(self: *StructSerializer) Error!void {
         if (self.backpatch) {
-            return finishDirect(self.parent_out, self.start, self.field_count, true);
+            return finishBackpatch(self.parent_out, self.start, self.field_count, true);
         }
         writeMapHeader(self.parent_out, self.field_count) catch {
             self.aw.deinit();
@@ -241,7 +257,7 @@ pub const ArraySerializer = struct {
 
     pub fn end(self: *ArraySerializer) Error!void {
         if (self.backpatch) {
-            return finishDirect(self.parent_out, self.start, self.elem_count, false);
+            return finishBackpatch(self.parent_out, self.start, self.elem_count, false);
         }
         writeArrayHeader(self.parent_out, self.elem_count) catch {
             self.aw.deinit();
@@ -294,10 +310,10 @@ fn writeSint(out: *compat.Io.Writer, v: i64) !void {
     }
 }
 
-fn finishDirect(out: *compat.Io.Writer, start: usize, count: u32, map: bool) !void {
-    const header_len: usize = if (map)
-        if (count <= 15) 1 else if (count <= 0xffff) 3 else 5
-    else if (count <= 15) 1 else if (count <= 0xffff) 3 else 5;
+fn finishBackpatch(out: *compat.Io.Writer, start: usize, count: u32, map: bool) !void {
+    const header_len: usize = if (count <= 15) 1 else if (count <= 0xffff) 3 else 5;
+    if (start > out.end or out.end - start < 5)
+        return error.WriteFailed;
     const payload_start = start + 5;
     const payload_len = out.end - payload_start;
     const shift = 5 - header_len;


### PR DESCRIPTION
This PR improves the MessagePack backend by avoiding unnecessary allocations when container sizes are already available.

MessagePack containers include their element count in the header. The previous implementation did not always take advantage of this information, which caused extra allocations and copies during serialization and deserialization.

This PR is limited to the MessagePack backend:

- allocate arrays with their known length during deserialization
- avoid temporary container buffers in in-memory serialization by patching headers after writing their contents

The streaming writer APIs keep the existing buffered path because flushed output cannot be modified afterwards.

I also added benchmark coverage for these container paths.

On the built-in serde.zig benchmarks (ReleaseFast, aarch64-macos):

| Case | Before | After | Result |
| :---: | ---: | ---: | ---: |
| msgpack.nested.serialize | 22.25 µs | 6.53 µs | ~3.4× faster |
| msgpack.nested.deserialize | 25.97 µs | 11.61 µs | ~2.2× faster |

Validation:

```sh
zig build test
zig build bench -Dbench-filter=msgpack
```