### PR TITLE
fix(msgpack): write known-length containers directly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,14 @@ Each format lives in `src/formats/<name>/` and must provide:
 
 Both interfaces are verified at comptime by `isSerializer` / `isDeserializer` in `src/core/interface.zig`.
 
+Length-prefixed formats may additionally declare `beginArrayLen` / `beginStructLen`.
+The core calls them instead of `beginArray` / `beginStruct` whenever the element
+count is known up front, so the header can be written before the payload instead
+of buffering it. Declare both or neither, and note the contract: the caller emits
+exactly the declared number of elements, so a serializer should verify the count
+under `std.debug.runtime_safety`. See `hasKnownLengthContainers` in
+`src/core/interface.zig`.
+
 Add the new format to:
 - `src/root.zig` — import and re-export
 - `build.zig` — add fuzz target if applicable

--- a/src/core/interface.zig
+++ b/src/core/interface.zig
@@ -11,6 +11,32 @@ pub fn isSerializer(comptime S: type) bool {
         @hasDecl(S, "beginStruct");
 }
 
+/// Whether S implements the optional length-aware container API.
+///
+/// `beginArray` / `beginStruct` let a serializer discover the element count
+/// only at `end()`, which forces length-prefixed formats such as MessagePack
+/// to buffer the payload. A serializer may additionally declare:
+///
+///     fn beginArrayLen(self: *S, len: usize) Error!ArrayContainer
+///     fn beginStructLen(self: *S, len: usize) Error!StructContainer
+///
+/// which the core calls whenever the count is known up front, letting the
+/// serializer emit the header first and stream the payload.
+///
+/// Contract: the caller must emit **exactly** `len` elements or fields into
+/// the returned container before calling `end()`. Writing a different number
+/// silently produces a malformed document, so serializers are encouraged to
+/// assert the count under `std.debug.runtime_safety`.
+///
+/// Both declarations must be present or absent together.
+pub fn hasKnownLengthContainers(comptime S: type) bool {
+    const has_array = @hasDecl(S, "beginArrayLen");
+    const has_struct = @hasDecl(S, "beginStructLen");
+    if (has_array != has_struct)
+        @compileError(@typeName(S) ++ " must declare both beginArrayLen and beginStructLen, or neither");
+    return has_array;
+}
+
 /// Whether D implements the full Deserializer interface.
 pub fn isDeserializer(comptime D: type) bool {
     return @hasDecl(D, "deserializeBool") and

--- a/src/core/mod.zig
+++ b/src/core/mod.zig
@@ -26,6 +26,7 @@ pub const deserializeWith = deserialize_mod.deserializeWith;
 pub const deserializeSchema = deserialize_mod.deserializeSchema;
 
 pub const isSerializer = interface.isSerializer;
+pub const hasKnownLengthContainers = interface.hasKnownLengthContainers;
 pub const isDeserializer = interface.isDeserializer;
 
 pub const NamingConvention = options.NamingConvention;

--- a/src/core/serialize.zig
+++ b/src/core/serialize.zig
@@ -90,7 +90,10 @@ fn serializeOptionalSchema(comptime T: type, value: T, serializer: anytype, comp
 
 fn serializeArraySchema(comptime T: type, value: T, serializer: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     const child = Child(T);
-    var arr = try serializer.beginArray();
+    var arr = if (comptime @hasDecl(@TypeOf(serializer.*), "beginArrayLen"))
+        try serializer.beginArrayLen(value.len)
+    else
+        try serializer.beginArray();
     defer cleanupContainer(&arr);
     for (value) |elem| {
         try serializeSchema(child, elem, &arr, {}, map);
@@ -100,7 +103,10 @@ fn serializeArraySchema(comptime T: type, value: T, serializer: anytype, comptim
 
 fn serializeSliceSchema(comptime T: type, value: T, serializer: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     const child = Child(T);
-    var arr = try serializer.beginArray();
+    var arr = if (comptime @hasDecl(@TypeOf(serializer.*), "beginArrayLen"))
+        try serializer.beginArrayLen(value.len)
+    else
+        try serializer.beginArray();
     defer cleanupContainer(&arr);
     for (value) |elem| {
         try serializeSchema(child, elem, &arr, {}, map);
@@ -108,9 +114,34 @@ fn serializeSliceSchema(comptime T: type, value: T, serializer: anytype, comptim
     return arr.end();
 }
 
+fn countStructFieldsSchema(comptime T: type, value: T, comptime schema: anytype) usize {
+    var count: usize = 0;
+    inline for (reflect.structFields(T)) |field| {
+        if (comptime options.shouldSkipFieldSchema(T, field.name, .serialize, schema)) continue;
+
+        if (comptime options.isFlattenedFieldSchema(T, field.name, schema)) {
+            if (@typeInfo(field.type) != .@"struct")
+                @compileError("Flatten requires a struct type, got " ++ @typeName(field.type));
+            count += reflect.structFields(field.type).len;
+            continue;
+        }
+
+        const field_value = @field(value, field.name);
+        const skip_null = comptime options.isSkipIfNullSchema(T, field.name, schema) and @typeInfo(field.type) == .optional;
+        const skip_empty = comptime options.isSkipIfEmptySchema(T, field.name, schema) and @typeInfo(field.type) == .pointer;
+        if (!((skip_null and field_value == null) or (skip_empty and field_value.len == 0))) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
 fn serializeStructSchema(comptime T: type, value: T, serializer: anytype, comptime schema: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     _ = map;
-    var ss = try serializer.beginStruct();
+    var ss = if (comptime @hasDecl(@TypeOf(serializer.*), "beginStructLen"))
+        try serializer.beginStructLen(countStructFieldsSchema(T, value, schema))
+    else
+        try serializer.beginStruct();
     defer cleanupContainer(&ss);
 
     inline for (reflect.structFields(T)) |field| {
@@ -155,9 +186,13 @@ fn serializeStructSchema(comptime T: type, value: T, serializer: anytype, compti
 }
 
 fn serializeTupleSchema(comptime T: type, value: T, serializer: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
-    var arr = try serializer.beginArray();
+    const fields = reflect.structFields(T);
+    var arr = if (comptime @hasDecl(@TypeOf(serializer.*), "beginArrayLen"))
+        try serializer.beginArrayLen(fields.len)
+    else
+        try serializer.beginArray();
     defer cleanupContainer(&arr);
-    inline for (reflect.structFields(T)) |field| {
+    inline for (fields) |field| {
         try serializeSchema(field.type, @field(value, field.name), &arr, {}, map);
     }
     return arr.end();

--- a/src/core/serialize.zig
+++ b/src/core/serialize.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const kind_mod = @import("kind.zig");
+const interface = @import("interface.zig");
 const options = @import("options.zig");
 const compat = @import("compat");
 const reflect = @import("../reflect.zig");
@@ -80,6 +81,37 @@ fn findOobAdapter(comptime T: type, comptime map: anytype) ?type {
     return null;
 }
 
+fn ErrorPayload(comptime F: type) type {
+    return @typeInfo(@typeInfo(F).@"fn".return_type.?).error_union.payload;
+}
+
+fn ArrayContainer(comptime S: type) type {
+    if (comptime interface.hasKnownLengthContainers(S)) return ErrorPayload(@TypeOf(S.beginArrayLen));
+    return ErrorPayload(@TypeOf(S.beginArray));
+}
+
+fn StructContainer(comptime S: type) type {
+    if (comptime interface.hasKnownLengthContainers(S)) return ErrorPayload(@TypeOf(S.beginStructLen));
+    return ErrorPayload(@TypeOf(S.beginStruct));
+}
+
+/// Opens an array container, handing `len` to serializers that implement the
+/// optional length-aware API so length-prefixed formats can emit the header
+/// before the payload. The caller must then emit exactly `len` elements.
+/// See `hasKnownLengthContainers` in interface.zig.
+inline fn beginArrayN(serializer: anytype, len: usize) @TypeOf(serializer.*).Error!ArrayContainer(@TypeOf(serializer.*)) {
+    if (comptime interface.hasKnownLengthContainers(@TypeOf(serializer.*)))
+        return serializer.beginArrayLen(len);
+    return serializer.beginArray();
+}
+
+/// Struct counterpart of `beginArrayN`. The caller must emit exactly `len` fields.
+inline fn beginStructN(serializer: anytype, len: usize) @TypeOf(serializer.*).Error!StructContainer(@TypeOf(serializer.*)) {
+    if (comptime interface.hasKnownLengthContainers(@TypeOf(serializer.*)))
+        return serializer.beginStructLen(len);
+    return serializer.beginStruct();
+}
+
 fn serializeOptionalSchema(comptime T: type, value: T, serializer: anytype, comptime schema: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     if (value) |v| {
         return serializeSchema(Child(T), v, serializer, schema, map);
@@ -90,10 +122,7 @@ fn serializeOptionalSchema(comptime T: type, value: T, serializer: anytype, comp
 
 fn serializeArraySchema(comptime T: type, value: T, serializer: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     const child = Child(T);
-    var arr = if (comptime @hasDecl(@TypeOf(serializer.*), "beginArrayLen"))
-        try serializer.beginArrayLen(value.len)
-    else
-        try serializer.beginArray();
+    var arr = try beginArrayN(serializer, value.len);
     defer cleanupContainer(&arr);
     for (value) |elem| {
         try serializeSchema(child, elem, &arr, {}, map);
@@ -103,10 +132,7 @@ fn serializeArraySchema(comptime T: type, value: T, serializer: anytype, comptim
 
 fn serializeSliceSchema(comptime T: type, value: T, serializer: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     const child = Child(T);
-    var arr = if (comptime @hasDecl(@TypeOf(serializer.*), "beginArrayLen"))
-        try serializer.beginArrayLen(value.len)
-    else
-        try serializer.beginArray();
+    var arr = try beginArrayN(serializer, value.len);
     defer cleanupContainer(&arr);
     for (value) |elem| {
         try serializeSchema(child, elem, &arr, {}, map);
@@ -114,6 +140,12 @@ fn serializeSliceSchema(comptime T: type, value: T, serializer: anytype, comptim
     return arr.end();
 }
 
+/// Number of fields `serializeStructSchema` will emit for `value`.
+///
+/// This must stay in lockstep with the emit loop below: the count is written
+/// into the container header before any field is serialized, so a mismatch
+/// silently produces a malformed document. Any new skip or flatten rule has to
+/// be mirrored in both places.
 fn countStructFieldsSchema(comptime T: type, value: T, comptime schema: anytype) usize {
     var count: usize = 0;
     inline for (reflect.structFields(T)) |field| {
@@ -138,10 +170,7 @@ fn countStructFieldsSchema(comptime T: type, value: T, comptime schema: anytype)
 
 fn serializeStructSchema(comptime T: type, value: T, serializer: anytype, comptime schema: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     _ = map;
-    var ss = if (comptime @hasDecl(@TypeOf(serializer.*), "beginStructLen"))
-        try serializer.beginStructLen(countStructFieldsSchema(T, value, schema))
-    else
-        try serializer.beginStruct();
+    var ss = try beginStructN(serializer, countStructFieldsSchema(T, value, schema));
     defer cleanupContainer(&ss);
 
     inline for (reflect.structFields(T)) |field| {
@@ -187,10 +216,7 @@ fn serializeStructSchema(comptime T: type, value: T, serializer: anytype, compti
 
 fn serializeTupleSchema(comptime T: type, value: T, serializer: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     const fields = reflect.structFields(T);
-    var arr = if (comptime @hasDecl(@TypeOf(serializer.*), "beginArrayLen"))
-        try serializer.beginArrayLen(fields.len)
-    else
-        try serializer.beginArray();
+    var arr = try beginArrayN(serializer, fields.len);
     defer cleanupContainer(&arr);
     inline for (fields) |field| {
         try serializeSchema(field.type, @field(value, field.name), &arr, {}, map);
@@ -220,7 +246,7 @@ fn serializeUnionExternalSchema(comptime T: type, value: T, serializer: anytype,
                 return serializer.serializeString(wire_name);
             } else {
                 const payload = @field(value, field.name);
-                var ss = try serializer.beginStruct();
+                var ss = try beginStructN(serializer, 1);
                 defer cleanupContainer(&ss);
                 try ss.serializeField(wire_name, payload);
                 return ss.end();
@@ -234,14 +260,15 @@ fn serializeUnionInternalSchema(comptime T: type, value: T, serializer: anytype,
     inline for (reflect.unionFields(T)) |field| {
         if (value == @field(T, field.name)) {
             const wire_name = comptime options.wireFieldNameForDir(T, field.name, schema, .serialize);
-            var ss = try serializer.beginStruct();
+            if (comptime field.type != void and @typeInfo(field.type) != .@"struct")
+                @compileError("Internal tagging requires struct payloads, got " ++ @typeName(field.type));
+            const payload_fields = comptime if (field.type == void) 0 else reflect.structFields(field.type).len;
+            var ss = try beginStructN(serializer, 1 + payload_fields);
             defer cleanupContainer(&ss);
             try ss.serializeField(tag_field_name, @as([]const u8, wire_name));
             if (field.type == void) {
                 return ss.end();
             } else {
-                if (@typeInfo(field.type) != .@"struct")
-                    @compileError("Internal tagging requires struct payloads, got " ++ @typeName(field.type));
                 const payload = @field(value, field.name);
                 inline for (reflect.structFields(field.type)) |sf| {
                     try ss.serializeField(sf.name, @field(payload, sf.name));
@@ -258,7 +285,7 @@ fn serializeUnionAdjacentSchema(comptime T: type, value: T, serializer: anytype,
     inline for (reflect.unionFields(T)) |field| {
         if (value == @field(T, field.name)) {
             const wire_name = comptime options.wireFieldNameForDir(T, field.name, schema, .serialize);
-            var ss = try serializer.beginStruct();
+            var ss = try beginStructN(serializer, if (field.type == void) 1 else 2);
             defer cleanupContainer(&ss);
             try ss.serializeField(tag_field_name, @as([]const u8, wire_name));
             if (field.type != void) {
@@ -299,7 +326,12 @@ fn serializeEnumSchema(comptime T: type, value: T, serializer: anytype, comptime
 
 fn serializeMapSchema(comptime T: type, value: T, serializer: anytype, comptime map: anytype) @TypeOf(serializer.*).Error!void {
     _ = map;
-    var ss = try serializer.beginStruct();
+    // Map-like types are duck-typed on getOrPut + iterator, so `count` is not
+    // guaranteed; fall back to the counting container when it is missing.
+    var ss = if (comptime @hasDecl(T, "count"))
+        try beginStructN(serializer, value.count())
+    else
+        try serializer.beginStruct();
     defer cleanupContainer(&ss);
     var it = value.iterator();
     while (it.next()) |entry| {

--- a/src/formats/msgpack/deserializer.zig
+++ b/src/formats/msgpack/deserializer.zig
@@ -366,84 +366,47 @@ fn readIntValue(d: *Deserializer, tag: u8) DeserializeError!i64 {
     };
 }
 
-// Skip a single msgpack value by tag. Used for unknown struct fields.
-fn skipByTag(d: *Deserializer, tag: u8) DeserializeError!void {
-    // nil, false, true
-    if (tag == 0xc0 or tag == 0xc2 or tag == 0xc3) return;
+// Skip a single msgpack value by tag. Containers add their children to a
+// pending count instead of recursing, keeping deeply nested unknown values off
+// the call stack.
+fn skipByTag(d: *Deserializer, first_tag: u8) DeserializeError!void {
+    var remaining: usize = 1;
+    var tag = first_tag;
+    while (remaining > 0) {
+        remaining -= 1;
 
-    // Positive fixint, negative fixint
-    if (tag <= 0x7f or tag >= 0xe0) return;
-
-    // Fixed-size numeric types.
-    const skip_sizes = [_]struct { t: u8, s: usize }{
-        .{ .t = 0xcc, .s = 1 },
-        .{ .t = 0xcd, .s = 2 },
-        .{ .t = 0xce, .s = 4 },
-        .{ .t = 0xcf, .s = 8 },
-        .{ .t = 0xd0, .s = 1 },
-        .{ .t = 0xd1, .s = 2 },
-        .{ .t = 0xd2, .s = 4 },
-        .{ .t = 0xd3, .s = 8 },
-        .{ .t = 0xca, .s = 4 },
-        .{ .t = 0xcb, .s = 8 },
-    };
-    for (skip_sizes) |entry| {
-        if (tag == entry.t) {
-            _ = try d.readSlice(entry.s);
-            return;
+        if (tag == 0xc0 or tag == 0xc2 or tag == 0xc3 or tag <= 0x7f or tag >= 0xe0) {
+            // nil, bool, positive fixint, negative fixint
+        } else switch (tag) {
+            0xcc, 0xd0 => _ = try d.readSlice(1),
+            0xcd, 0xd1 => _ = try d.readSlice(2),
+            0xce, 0xd2, 0xca => _ = try d.readSlice(4),
+            0xcf, 0xd3, 0xcb => _ = try d.readSlice(8),
+            0xc4 => _ = try d.readSlice(try d.readByte()),
+            0xc5 => _ = try d.readSlice(try d.readBE(u16)),
+            0xc6 => _ = try d.readSlice(try d.readBE(u32)),
+            0xd9, 0xda, 0xdb => _ = try d.readSlice(try readStrLen(tag, d)),
+            0xdc, 0xdd => remaining +|= try readArrayLen(tag, d),
+            0xde, 0xdf => {
+                const len = try readMapLen(tag, d);
+                remaining +|= len;
+                remaining +|= len;
+            },
+            else => {
+                if (tag & 0xe0 == 0xa0) {
+                    _ = try d.readSlice(tag & 0x1f);
+                } else if (tag & 0xf0 == 0x90) {
+                    remaining +|= tag & 0x0f;
+                } else if (tag & 0xf0 == 0x80) {
+                    const len: usize = tag & 0x0f;
+                    remaining +|= len;
+                    remaining +|= len;
+                } else return error.UnexpectedTag;
+            },
         }
-    }
 
-    // Strings.
-    if (tag & 0xe0 == 0xa0 or tag == 0xd9 or tag == 0xda or tag == 0xdb) {
-        const len = try readStrLen(tag, d);
-        _ = try d.readSlice(len);
-        return;
+        if (remaining > 0) tag = try d.readByte();
     }
-
-    // Binary.
-    switch (tag) {
-        0xc4 => {
-            const len: usize = try d.readByte();
-            _ = try d.readSlice(len);
-            return;
-        },
-        0xc5 => {
-            const len: usize = try d.readBE(u16);
-            _ = try d.readSlice(len);
-            return;
-        },
-        0xc6 => {
-            const len: usize = try d.readBE(u32);
-            _ = try d.readSlice(len);
-            return;
-        },
-        else => {},
-    }
-
-    // Arrays.
-    if (tag & 0xf0 == 0x90 or tag == 0xdc or tag == 0xdd) {
-        const len = try readArrayLen(tag, d);
-        for (0..len) |_| {
-            const inner = try d.readByte();
-            try skipByTag(d, inner);
-        }
-        return;
-    }
-
-    // Maps.
-    if (tag & 0xf0 == 0x80 or tag == 0xde or tag == 0xdf) {
-        const len = try readMapLen(tag, d);
-        for (0..len) |_| {
-            const k = try d.readByte();
-            try skipByTag(d, k);
-            const v = try d.readByte();
-            try skipByTag(d, v);
-        }
-        return;
-    }
-
-    return error.UnexpectedTag;
 }
 
 fn errorFromAny(err: anyerror) DeserializeError {
@@ -593,4 +556,17 @@ test "deserialize unexpected eof" {
 test "deserialize overflow" {
     var d = Deserializer.init(&.{ 0xcd, 0x01, 0x00 }); // 256 as uint16
     try testing.expectError(error.Overflow, d.deserializeInt(u8));
+}
+
+test "skip deeply nested arrays" {
+    const depth = 100_000;
+    const input = try testing.allocator.alloc(u8, depth + 1);
+    defer testing.allocator.free(input);
+    @memset(input[0..depth], 0x91);
+    input[depth] = 0;
+
+    var d = Deserializer.init(input);
+    const tag = try d.readByte();
+    try skipByTag(&d, tag);
+    try testing.expectEqual(input.len, d.pos);
 }

--- a/src/formats/msgpack/deserializer.zig
+++ b/src/formats/msgpack/deserializer.zig
@@ -177,15 +177,22 @@ pub const Deserializer = struct {
         const tag = try self.readByte();
         const len = readArrayLen(tag, self) catch return error.WrongType;
 
-        var items: std.ArrayList(Child) = .empty;
-        errdefer items.deinit(allocator);
-
-        for (0..len) |_| {
-            const elem = try core_deserialize.deserialize(Child, allocator, self, .{});
-            items.append(allocator, elem) catch return error.OutOfMemory;
+        if (len > self.input.len - self.pos) return error.UnexpectedEof;
+        const items = allocator.alloc(Child, len) catch return error.OutOfMemory;
+        var initialized: usize = 0;
+        errdefer {
+            for (items[0..initialized]) |elem| {
+                core_deserialize.freeAllocated(Child, elem, allocator);
+            }
+            allocator.free(items);
         }
 
-        return items.toOwnedSlice(allocator) catch return error.OutOfMemory;
+        for (items) |*item| {
+            item.* = try core_deserialize.deserialize(Child, allocator, self, .{});
+            initialized += 1;
+        }
+
+        return items;
     }
 
     pub fn deserializeSeqAccess(self: *Deserializer) Error!SeqAccess {
@@ -551,6 +558,11 @@ test "deserialize wrong type error" {
 test "deserialize unexpected eof" {
     var d = Deserializer.init(&.{});
     try testing.expectError(error.UnexpectedEof, d.deserializeBool());
+}
+
+test "releases partial seq" {
+    var d = Deserializer.init(&.{ 0x92, 0xa1, 'a', 0xa1 });
+    try testing.expectError(error.UnexpectedEof, d.deserializeSeq([]const []const u8, testing.allocator));
 }
 
 test "deserialize overflow" {

--- a/src/formats/msgpack/deserializer.zig
+++ b/src/formats/msgpack/deserializer.zig
@@ -177,25 +177,15 @@ pub const Deserializer = struct {
         const tag = try self.readByte();
         const len = readArrayLen(tag, self) catch return error.WrongType;
 
-        // MessagePack provides the exact array length, so validate it before
-        // allocating and fill the final slice directly instead of growing an
-        // ArrayList while decoding each element.
-        if (len > self.input.len - self.pos) return error.UnexpectedEof;
-        const items = allocator.alloc(Child, len) catch return error.OutOfMemory;
-        var initialized: usize = 0;
-        errdefer {
-            for (items[0..initialized]) |elem| {
-                core_deserialize.freeAllocated(Child, elem, allocator);
-            }
-            allocator.free(items);
+        var items: std.ArrayList(Child) = .empty;
+        errdefer items.deinit(allocator);
+
+        for (0..len) |_| {
+            const elem = try core_deserialize.deserialize(Child, allocator, self, .{});
+            items.append(allocator, elem) catch return error.OutOfMemory;
         }
 
-        for (items) |*item| {
-            item.* = try core_deserialize.deserialize(Child, allocator, self, .{});
-            initialized += 1;
-        }
-
-        return items;
+        return items.toOwnedSlice(allocator) catch return error.OutOfMemory;
     }
 
     pub fn deserializeSeqAccess(self: *Deserializer) Error!SeqAccess {

--- a/src/formats/msgpack/mod.zig
+++ b/src/formats/msgpack/mod.zig
@@ -32,6 +32,11 @@ pub fn toSliceAlloc(allocator: std.mem.Allocator, value: anytype) ![:0]u8 {
 }
 
 /// Serialize a value to a writer in MessagePack format.
+///
+/// Containers whose length is known up front are streamed straight to `writer`
+/// rather than staged in memory, so a serialization error can leave a partially
+/// written value behind. Write into a buffer first if the sink must only ever
+/// see complete documents.
 pub fn toWriter(allocator: std.mem.Allocator, writer: *compat.Io.Writer, value: anytype) !void {
     var ser = Serializer.init(writer, allocator);
     try core_serialize.serialize(@TypeOf(value), value, &ser, .{});
@@ -49,6 +54,7 @@ pub fn toSliceSchema(allocator: std.mem.Allocator, value: anytype, comptime sche
 }
 
 /// Serialize a value to a writer in MessagePack format with an external schema.
+/// Streams like `toWriter`, with the same partial-write caveat.
 pub fn toWriterSchema(allocator: std.mem.Allocator, writer: *compat.Io.Writer, value: anytype, comptime schema: anytype) !void {
     var ser = Serializer.init(writer, allocator);
     try core_serialize.serializeSchema(@TypeOf(value), value, &ser, schema, .{});
@@ -241,6 +247,27 @@ test "known-length nested containers" {
         'd',  0xa6, 'v',  'a',  'l',  'u', 'e',  's',  0x92,
         4,    5,
     }, bytes);
+}
+
+test "roundtrip nested containers" {
+    const Entry = struct {
+        name: []const u8,
+        values: []const i32,
+    };
+    const Document = struct {
+        entries: []const Entry,
+    };
+    const document = Document{ .entries = &.{
+        .{ .name = "first", .values = &.{ 1, 2, 3 } },
+        .{ .name = "second", .values = &.{ 4, 5 } },
+    } };
+
+    const bytes = try toSlice(testing.allocator, document);
+    defer testing.allocator.free(bytes);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const decoded = try fromSlice(Document, arena.allocator(), bytes);
+    try testing.expectEqualDeep(document, decoded);
 }
 
 test "known-length array16" {
@@ -492,6 +519,61 @@ test "fromReader" {
     var reader: compat.Io.Reader = .fixed(bytes);
     const val = try fromReader(i32, testing.allocator, &reader);
     try testing.expectEqual(@as(i32, 42), val);
+}
+
+test "known-length union headers" {
+    const opts = @import("../../core/options.zig");
+
+    const External = union(enum) { ping: void, set: i32 };
+    const ext = try toSlice(testing.allocator, External{ .set = 5 });
+    defer testing.allocator.free(ext);
+    try testing.expectEqualSlices(u8, &.{ 0x81, 0xa3, 's', 'e', 't', 5 }, ext);
+
+    const Internal = union(enum) {
+        ping: void,
+        pair: struct { a: u8, b: u8 },
+
+        pub const serde = .{ .tag = opts.UnionTag.internal, .tag_field = "type" };
+    };
+    const internal_ping: Internal = .ping;
+    const int_void = try toSlice(testing.allocator, internal_ping);
+    defer testing.allocator.free(int_void);
+    try testing.expectEqualSlices(u8, &.{ 0x81, 0xa4, 't', 'y', 'p', 'e', 0xa4, 'p', 'i', 'n', 'g' }, int_void);
+
+    const int_pair = try toSlice(testing.allocator, Internal{ .pair = .{ .a = 1, .b = 2 } });
+    defer testing.allocator.free(int_pair);
+    try testing.expectEqual(@as(u8, 0x83), int_pair[0]);
+
+    const Adjacent = union(enum) {
+        ping: void,
+        data: i32,
+
+        pub const serde = .{ .tag = opts.UnionTag.adjacent, .tag_field = "t", .content_field = "c" };
+    };
+    const adjacent_ping: Adjacent = .ping;
+    const adj_void = try toSlice(testing.allocator, adjacent_ping);
+    defer testing.allocator.free(adj_void);
+    try testing.expectEqualSlices(u8, &.{ 0x81, 0xa1, 't', 0xa4, 'p', 'i', 'n', 'g' }, adj_void);
+
+    const adj_data = try toSlice(testing.allocator, Adjacent{ .data = 42 });
+    defer testing.allocator.free(adj_data);
+    try testing.expectEqualSlices(u8, &.{ 0x82, 0xa1, 't', 0xa4, 'd', 'a', 't', 'a', 0xa1, 'c', 42 }, adj_data);
+}
+
+test "known-length map header" {
+    var map = std.StringHashMap(u8).init(testing.allocator);
+    defer map.deinit();
+    try map.put("k", 1);
+
+    const bytes = try toSlice(testing.allocator, map);
+    defer testing.allocator.free(bytes);
+    try testing.expectEqualSlices(u8, &.{ 0x81, 0xa1, 'k', 1 }, bytes);
+
+    var empty = std.StringHashMap(u8).init(testing.allocator);
+    defer empty.deinit();
+    const empty_bytes = try toSlice(testing.allocator, empty);
+    defer testing.allocator.free(empty_bytes);
+    try testing.expectEqualSlices(u8, &.{0x80}, empty_bytes);
 }
 
 test "roundtrip union internal tagging" {
@@ -860,6 +942,19 @@ test "roundtrip i128 within i64 range" {
 
 test "deserialize error: truncated input" {
     const result = fromSlice(i32, testing.allocator, &.{ 0xce, 0x12 });
+    try testing.expectError(error.UnexpectedEof, result);
+}
+
+test "deserialize error: oversized array length" {
+    const input = [_]u8{ 0xdd, 0xff, 0xff, 0xff, 0xff, 0x01 };
+    const result = fromSlice([]const i32, testing.allocator, &input);
+    try testing.expectError(error.UnexpectedEof, result);
+}
+
+test "deserialize error: oversized map length" {
+    const Partial = struct { a: i32 };
+    const input = [_]u8{ 0xdf, 0xff, 0xff, 0xff, 0xff };
+    const result = fromSlice(Partial, testing.allocator, &input);
     try testing.expectError(error.UnexpectedEof, result);
 }
 

--- a/src/formats/msgpack/mod.zig
+++ b/src/formats/msgpack/mod.zig
@@ -215,6 +215,39 @@ test "roundtrip nested struct" {
     try testing.expectEqual(@as(i32, 42), val.inner.val);
 }
 
+test "known-length nested containers" {
+    const Entry = struct {
+        name: []const u8,
+        values: []const u16,
+    };
+    const Document = struct {
+        entries: []const Entry,
+    };
+    const document = Document{ .entries = &.{
+        .{ .name = "first", .values = &.{ 1, 2, 3 } },
+        .{ .name = "second", .values = &.{ 4, 5 } },
+    } };
+
+    const bytes = try toSlice(testing.allocator, document);
+    defer testing.allocator.free(bytes);
+    try testing.expectEqualSlices(u8, &.{
+        0x81, 0xa7, 'e',  'n',  't',  'r', 'i',  'e',  's',
+        0x92, 0x82, 0xa4, 'n',  'a',  'm', 'e',  0xa5, 'f',
+        'i',  'r',  's',  't',  0xa6, 'v', 'a',  'l',  'u',
+        'e',  's',  0x93, 1,    2,    3,   0x82, 0xa4, 'n',
+        'a',  'm',  'e',  0xa6, 's',  'e', 'c',  'o',  'n',
+        'd',  0xa6, 'v',  'a',  'l',  'u', 'e',  's',  0x92,
+        4,    5,
+    }, bytes);
+}
+
+test "known-length array16" {
+    const values = [_]u8{0} ** 16;
+    const bytes = try toSlice(testing.allocator, values);
+    defer testing.allocator.free(bytes);
+    try testing.expectEqualSlices(u8, &.{ 0xdc, 0, 16 }, bytes[0..3]);
+}
+
 test "roundtrip struct with optional field" {
     const Config = struct {
         name: []const u8,
@@ -705,6 +738,22 @@ test "serialize skip if null" {
 
     // Verify the non-null version is longer (contains the email field).
     try testing.expect(bytes2.len > bytes1.len);
+}
+
+test "skip null map count" {
+    const serde_opts = @import("../../core/options.zig");
+    const Partial = struct {
+        name: []const u8,
+        email: ?[]const u8,
+
+        pub const serde = .{
+            .skip = .{ .email = serde_opts.SkipMode.null },
+        };
+    };
+
+    const bytes = try toSlice(testing.allocator, Partial{ .name = "alice", .email = null });
+    defer testing.allocator.free(bytes);
+    try testing.expectEqualSlices(u8, &.{ 0x81, 0xa4, 'n', 'a', 'm', 'e', 0xa5, 'a', 'l', 'i', 'c', 'e' }, bytes);
 }
 
 test "serialize skip if empty" {

--- a/src/formats/msgpack/mod.zig
+++ b/src/formats/msgpack/mod.zig
@@ -15,7 +15,10 @@ pub const Deserializer = deserializer_mod.Deserializer;
 
 /// Serialize a value to a MessagePack byte slice. Caller owns the returned memory.
 pub fn toSlice(allocator: std.mem.Allocator, value: anytype) ![]u8 {
-    return serializer_mod.toSlice(allocator, value);
+    var aw: compat.Io.Writer.Allocating = .init(allocator);
+    var ser = Serializer.init(&aw.writer, allocator);
+    try core_serialize.serialize(@TypeOf(value), value, &ser, .{});
+    return aw.toOwnedSlice();
 }
 
 /// Serialize a value to a null-terminated MessagePack byte slice. Caller owns the returned memory.
@@ -37,7 +40,10 @@ pub fn toWriter(allocator: std.mem.Allocator, writer: *compat.Io.Writer, value: 
 
 /// Serialize a value to a MessagePack byte slice with an external schema.
 pub fn toSliceSchema(allocator: std.mem.Allocator, value: anytype, comptime schema: anytype) ![]u8 {
-    return serializer_mod.toSliceSchema(allocator, value, schema);
+    var aw: compat.Io.Writer.Allocating = .init(allocator);
+    var ser = Serializer.init(&aw.writer, allocator);
+    try core_serialize.serializeSchema(@TypeOf(value), value, &ser, schema, .{});
+    return aw.toOwnedSlice();
 }
 
 /// Serialize a value to a writer in MessagePack format with an external schema.
@@ -252,27 +258,6 @@ test "roundtrip array" {
     defer testing.allocator.free(bytes);
     const val = try fromSlice([3]i32, testing.allocator, bytes);
     try testing.expectEqual([3]i32{ 10, 20, 30 }, val);
-}
-
-test "roundtrip nested containers" {
-    const Entry = struct {
-        name: []const u8,
-        values: []const i32,
-    };
-    const Document = struct {
-        entries: []const Entry,
-    };
-    const document = Document{ .entries = &.{
-        .{ .name = "first", .values = &.{ 1, 2, 3 } },
-        .{ .name = "second", .values = &.{ 4, 5 } },
-    } };
-
-    const bytes = try toSlice(testing.allocator, document);
-    defer testing.allocator.free(bytes);
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const decoded = try fromSlice(Document, arena.allocator(), bytes);
-    try testing.expectEqualDeep(document, decoded);
 }
 
 test "roundtrip enum" {
@@ -798,12 +783,6 @@ test "roundtrip i128 within i64 range" {
 
 test "deserialize error: truncated input" {
     const result = fromSlice(i32, testing.allocator, &.{ 0xce, 0x12 });
-    try testing.expectError(error.UnexpectedEof, result);
-}
-
-test "deserialize error: oversized array length" {
-    const input = [_]u8{ 0xdd, 0xff, 0xff, 0xff, 0xff, 0x01 };
-    const result = fromSlice([]const i32, testing.allocator, &input);
     try testing.expectError(error.UnexpectedEof, result);
 }
 

--- a/src/formats/msgpack/mod.zig
+++ b/src/formats/msgpack/mod.zig
@@ -16,6 +16,7 @@ pub const Deserializer = deserializer_mod.Deserializer;
 /// Serialize a value to a MessagePack byte slice. Caller owns the returned memory.
 pub fn toSlice(allocator: std.mem.Allocator, value: anytype) ![]u8 {
     var aw: compat.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
     var ser = Serializer.init(&aw.writer, allocator);
     try core_serialize.serialize(@TypeOf(value), value, &ser, .{});
     return aw.toOwnedSlice();
@@ -41,6 +42,7 @@ pub fn toWriter(allocator: std.mem.Allocator, writer: *compat.Io.Writer, value: 
 /// Serialize a value to a MessagePack byte slice with an external schema.
 pub fn toSliceSchema(allocator: std.mem.Allocator, value: anytype, comptime schema: anytype) ![]u8 {
     var aw: compat.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
     var ser = Serializer.init(&aw.writer, allocator);
     try core_serialize.serializeSchema(@TypeOf(value), value, &ser, schema, .{});
     return aw.toOwnedSlice();

--- a/src/formats/msgpack/mod.zig
+++ b/src/formats/msgpack/mod.zig
@@ -242,7 +242,7 @@ test "known-length nested containers" {
 }
 
 test "known-length array16" {
-    const values = [_]u8{0} ** 16;
+    const values: [16]u8 = @splat(0);
     const bytes = try toSlice(testing.allocator, values);
     defer testing.allocator.free(bytes);
     try testing.expectEqualSlices(u8, &.{ 0xdc, 0, 16 }, bytes[0..3]);

--- a/src/formats/msgpack/mod.zig
+++ b/src/formats/msgpack/mod.zig
@@ -720,6 +720,32 @@ test "deny_unknown_fields" {
     try testing.expectEqual(@as(i32, 10), val.x);
 }
 
+test "skip nested unknown field" {
+    const Document = struct { id: u8 };
+    const bytes = [_]u8{
+        0x82,
+        0xa2,
+        'i',
+        'd',
+        1,
+        0xa5,
+        'e',
+        'x',
+        't',
+        'r',
+        'a',
+        0x91,
+        0x81,
+        0xa1,
+        'x',
+        0x92,
+        2,
+        3,
+    };
+    const value = try fromSlice(Document, testing.allocator, &bytes);
+    try testing.expectEqual(@as(u8, 1), value.id);
+}
+
 test "serialize skip if null" {
     const serde_opts = @import("../../core/options.zig");
     const Partial = struct {

--- a/src/formats/msgpack/serializer.zig
+++ b/src/formats/msgpack/serializer.zig
@@ -4,7 +4,27 @@ const core_serialize = @import("../../core/serialize.zig");
 
 const Allocator = std.mem.Allocator;
 
+/// `LengthOverflow` is returned when a container holds more than `maxInt(u32)`
+/// entries, which MessagePack headers cannot express.
 pub const SerializeError = error{ OutOfMemory, WriteFailed, LengthOverflow };
+
+/// Direct containers are handed an element count up front and cannot recover
+/// if the caller emits a different number, so the count is verified whenever
+/// runtime safety is on. Both the counters and the checks compile out
+/// otherwise.
+const count_check = std.debug.runtime_safety;
+
+const Counter = if (count_check) usize else void;
+
+fn counter(value: usize) Counter {
+    if (count_check) return value;
+    return {};
+}
+
+fn countMismatch(declared: Counter, written: Counter) void {
+    if (count_check and written != declared)
+        std.debug.panic("msgpack container declared {d} entries but wrote {d}", .{ declared, written });
+}
 
 pub const Serializer = struct {
     out: *compat.Io.Writer,
@@ -103,21 +123,24 @@ pub const Serializer = struct {
     pub fn beginStructLen(self: *Serializer, len: usize) Error!DirectStructSerializer {
         if (len > std.math.maxInt(u32)) return error.LengthOverflow;
         writeMapHeader(self.out, @intCast(len)) catch return error.WriteFailed;
-        return .{ .out = self.out, .allocator = self.allocator };
+        return .{ .out = self.out, .allocator = self.allocator, .declared = counter(len) };
     }
 
     pub fn beginArrayLen(self: *Serializer, len: usize) Error!DirectArraySerializer {
         if (len > std.math.maxInt(u32)) return error.LengthOverflow;
         writeArrayHeader(self.out, @intCast(len)) catch return error.WriteFailed;
-        return .{ .out = self.out, .allocator = self.allocator };
+        return .{ .out = self.out, .allocator = self.allocator, .declared = counter(len) };
     }
 };
 
 /// A container whose header has already been written. This is deliberately a
 /// separate type so the hot path has no runtime "buffered or direct" branch.
+/// Mirrors the surface of `StructSerializer`.
 pub const DirectStructSerializer = struct {
     out: *compat.Io.Writer,
     allocator: Allocator,
+    declared: Counter,
+    written: Counter = counter(0),
 
     pub const Error = SerializeError;
 
@@ -125,40 +148,31 @@ pub const DirectStructSerializer = struct {
         var child = Serializer.init(self.out, self.allocator);
         try child.serializeString(key);
         try core_serialize.serialize(@TypeOf(value), value, &child, .{});
+        if (count_check) self.written += 1;
     }
 
     pub fn serializeEntry(self: *DirectStructSerializer, key: anytype, value: anytype) Error!void {
         var child = Serializer.init(self.out, self.allocator);
         try core_serialize.serialize(@TypeOf(key), key, &child, .{});
         try core_serialize.serialize(@TypeOf(value), value, &child, .{});
+        if (count_check) self.written += 1;
     }
 
-    pub fn beginStruct(self: *DirectStructSerializer) Error!StructSerializer {
-        return Serializer.init(self.out, self.allocator).beginStruct();
+    pub fn end(self: *DirectStructSerializer) Error!void {
+        countMismatch(self.declared, self.written);
     }
-
-    pub fn beginArray(self: *DirectStructSerializer) Error!ArraySerializer {
-        return Serializer.init(self.out, self.allocator).beginArray();
-    }
-
-    pub fn beginStructLen(self: *DirectStructSerializer, len: usize) Error!DirectStructSerializer {
-        return Serializer.init(self.out, self.allocator).beginStructLen(len);
-    }
-
-    pub fn beginArrayLen(self: *DirectStructSerializer, len: usize) Error!DirectArraySerializer {
-        return Serializer.init(self.out, self.allocator).beginArrayLen(len);
-    }
-
-    pub fn end(_: *DirectStructSerializer) Error!void {}
 };
 
 pub const DirectArraySerializer = struct {
     out: *compat.Io.Writer,
     allocator: Allocator,
+    declared: Counter,
+    written: Counter = counter(0),
 
     pub const Error = SerializeError;
 
     fn child(self: *DirectArraySerializer) Serializer {
+        if (count_check) self.written += 1;
         return Serializer.init(self.out, self.allocator);
     }
 
@@ -217,7 +231,9 @@ pub const DirectArraySerializer = struct {
         return serializer.beginArrayLen(len);
     }
 
-    pub fn end(_: *DirectArraySerializer) Error!void {}
+    pub fn end(self: *DirectArraySerializer) Error!void {
+        countMismatch(self.declared, self.written);
+    }
 };
 
 // Buffers serialized fields, writes map header + buffered data on end().
@@ -608,6 +624,75 @@ test "serialize bytes empty" {
     const out = aw.toOwnedSlice() catch unreachable;
     defer testing.allocator.free(out);
     try testing.expectEqualSlices(u8, &.{ 0xc4, 0 }, out);
+}
+
+// The buffered containers are no longer reached through the core encoder,
+// which always knows the length of Zig's own aggregates. They stay part of the
+// public interface for custom `zerdeSerialize` implementations, so exercise
+// them directly.
+
+const CustomSeq = struct {
+    items: []const i32,
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        var arr = try serializer.beginArray();
+        for (self.items) |v| try arr.serializeInt(v);
+        try arr.end();
+    }
+};
+
+const CustomNested = struct {
+    pub fn zerdeSerialize(_: @This(), serializer: anytype) !void {
+        var arr = try serializer.beginArray();
+        var inner = try arr.beginStruct();
+        try inner.serializeEntry(@as([]const u8, "k"), @as(u8, 1));
+        try inner.end();
+        var deep = try arr.beginArray();
+        try deep.serializeBool(true);
+        try deep.end();
+        try arr.serializeNull();
+        try arr.end();
+    }
+};
+
+test "buffered array serializer via custom serializer" {
+    const out = try serializeToBytes(CustomSeq{ .items = &.{ 1, 2, 3 } });
+    defer testing.allocator.free(out);
+    try testing.expectEqualSlices(u8, &.{ 0x93, 1, 2, 3 }, out);
+}
+
+test "buffered array serializer counts nested containers" {
+    const out = try serializeToBytes(CustomNested{});
+    defer testing.allocator.free(out);
+    try testing.expectEqualSlices(u8, &.{ 0x93, 0x81, 0xa1, 'k', 1, 0x91, 0xc3, 0xc0 }, out);
+}
+
+test "buffered array serializer inside a known-length container" {
+    const Doc = struct { seq: CustomSeq, tail: u8 };
+    const out = try serializeToBytes(Doc{ .seq = .{ .items = &.{ 7, 8 } }, .tail = 9 });
+    defer testing.allocator.free(out);
+    try testing.expectEqualSlices(u8, &.{
+        0x82, 0xa3, 's', 'e', 'q', 0x92, 7, 8,
+        0xa4, 't',  'a', 'i', 'l', 9,
+    }, out);
+}
+
+test "buffered array serializer as a known-length array element" {
+    const out = try serializeToBytes(@as([]const CustomSeq, &.{
+        .{ .items = &.{1} },
+        .{ .items = &.{ 2, 3 } },
+    }));
+    defer testing.allocator.free(out);
+    try testing.expectEqualSlices(u8, &.{ 0x92, 0x91, 1, 0x92, 2, 3 }, out);
+}
+
+test "beginArrayLen rejects counts beyond a u32 header" {
+    if (@sizeOf(usize) <= 4) return error.SkipZigTest;
+    var aw: compat.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var ser = Serializer.init(&aw.writer, testing.allocator);
+    try testing.expectError(error.LengthOverflow, ser.beginArrayLen(@as(usize, std.math.maxInt(u32)) + 1));
+    try testing.expectError(error.LengthOverflow, ser.beginStructLen(@as(usize, std.math.maxInt(u32)) + 1));
 }
 
 test "serialize union with payload" {

--- a/src/formats/msgpack/serializer.zig
+++ b/src/formats/msgpack/serializer.zig
@@ -96,6 +96,126 @@ pub const Serializer = struct {
             .elem_count = 0,
         };
     }
+
+    /// Writes a compact header immediately when the caller already knows the
+    /// element count. The generic streaming API remains buffered because its
+    /// final count may depend on runtime decisions.
+    pub fn beginStructLen(self: *Serializer, len: usize) Error!DirectStructSerializer {
+        writeMapHeader(self.out, @intCast(len)) catch return error.WriteFailed;
+        return .{ .out = self.out, .allocator = self.allocator };
+    }
+
+    pub fn beginArrayLen(self: *Serializer, len: usize) Error!DirectArraySerializer {
+        writeArrayHeader(self.out, @intCast(len)) catch return error.WriteFailed;
+        return .{ .out = self.out, .allocator = self.allocator };
+    }
+};
+
+/// A container whose header has already been written. This is deliberately a
+/// separate type so the hot path has no runtime "buffered or direct" branch.
+pub const DirectStructSerializer = struct {
+    out: *compat.Io.Writer,
+    allocator: Allocator,
+
+    pub const Error = SerializeError;
+
+    pub fn serializeField(self: *DirectStructSerializer, comptime key: []const u8, value: anytype) Error!void {
+        var child = Serializer.init(self.out, self.allocator);
+        try child.serializeString(key);
+        try core_serialize.serialize(@TypeOf(value), value, &child, .{});
+    }
+
+    pub fn serializeEntry(self: *DirectStructSerializer, key: anytype, value: anytype) Error!void {
+        var child = Serializer.init(self.out, self.allocator);
+        try core_serialize.serialize(@TypeOf(key), key, &child, .{});
+        try core_serialize.serialize(@TypeOf(value), value, &child, .{});
+    }
+
+    pub fn beginStruct(self: *DirectStructSerializer) Error!StructSerializer {
+        return Serializer.init(self.out, self.allocator).beginStruct();
+    }
+
+    pub fn beginArray(self: *DirectStructSerializer) Error!ArraySerializer {
+        return Serializer.init(self.out, self.allocator).beginArray();
+    }
+
+    pub fn beginStructLen(self: *DirectStructSerializer, len: usize) Error!DirectStructSerializer {
+        return Serializer.init(self.out, self.allocator).beginStructLen(len);
+    }
+
+    pub fn beginArrayLen(self: *DirectStructSerializer, len: usize) Error!DirectArraySerializer {
+        return Serializer.init(self.out, self.allocator).beginArrayLen(len);
+    }
+
+    pub fn end(_: *DirectStructSerializer) Error!void {}
+};
+
+pub const DirectArraySerializer = struct {
+    out: *compat.Io.Writer,
+    allocator: Allocator,
+
+    pub const Error = SerializeError;
+
+    fn child(self: *DirectArraySerializer) Serializer {
+        return Serializer.init(self.out, self.allocator);
+    }
+
+    pub fn serializeBool(self: *DirectArraySerializer, value: bool) Error!void {
+        var serializer = self.child();
+        try serializer.serializeBool(value);
+    }
+
+    pub fn serializeInt(self: *DirectArraySerializer, value: anytype) Error!void {
+        var serializer = self.child();
+        try serializer.serializeInt(value);
+    }
+
+    pub fn serializeFloat(self: *DirectArraySerializer, value: anytype) Error!void {
+        var serializer = self.child();
+        try serializer.serializeFloat(value);
+    }
+
+    pub fn serializeString(self: *DirectArraySerializer, value: []const u8) Error!void {
+        var serializer = self.child();
+        try serializer.serializeString(value);
+    }
+
+    pub fn serializeBytes(self: *DirectArraySerializer, value: []const u8) Error!void {
+        var serializer = self.child();
+        try serializer.serializeBytes(value);
+    }
+
+    pub fn serializeNull(self: *DirectArraySerializer) Error!void {
+        var serializer = self.child();
+        try serializer.serializeNull();
+    }
+
+    pub fn serializeVoid(self: *DirectArraySerializer) Error!void {
+        var serializer = self.child();
+        try serializer.serializeVoid();
+    }
+
+    pub fn beginStruct(self: *DirectArraySerializer) Error!StructSerializer {
+        var serializer = self.child();
+        return serializer.beginStruct();
+    }
+
+    pub fn beginArray(self: *DirectArraySerializer) Error!ArraySerializer {
+        var serializer = self.child();
+        return serializer.beginArray();
+    }
+
+    pub fn beginStructLen(self: *DirectArraySerializer, len: usize) Error!DirectStructSerializer {
+        var serializer = self.child();
+        return serializer.beginStructLen(len);
+    }
+
+    pub fn beginArrayLen(self: *DirectArraySerializer, len: usize) Error!DirectArraySerializer {
+        var serializer = self.child();
+        return serializer.beginArrayLen(len);
+    }
+
+    pub fn end(_: *DirectArraySerializer) Error!void {}
 };
 
 // Buffers serialized fields, writes map header + buffered data on end().

--- a/src/formats/msgpack/serializer.zig
+++ b/src/formats/msgpack/serializer.zig
@@ -6,35 +6,14 @@ const Allocator = std.mem.Allocator;
 
 pub const SerializeError = error{ OutOfMemory, WriteFailed };
 
-pub fn toSlice(allocator: Allocator, value: anytype) ![]u8 {
-    var aw: compat.Io.Writer.Allocating = .init(allocator);
-    errdefer aw.deinit();
-    var serializer = Serializer.initBackpatch(&aw.writer, allocator);
-    try core_serialize.serialize(@TypeOf(value), value, &serializer, .{});
-    return aw.toOwnedSlice();
-}
-
-pub fn toSliceSchema(allocator: Allocator, value: anytype, comptime schema: anytype) ![]u8 {
-    var aw: compat.Io.Writer.Allocating = .init(allocator);
-    errdefer aw.deinit();
-    var serializer = Serializer.initBackpatch(&aw.writer, allocator);
-    try core_serialize.serializeSchema(@TypeOf(value), value, &serializer, schema, .{});
-    return aw.toOwnedSlice();
-}
-
 pub const Serializer = struct {
     out: *compat.Io.Writer,
     allocator: Allocator,
-    backpatch_containers: bool = false,
 
     pub const Error = SerializeError;
 
     pub fn init(out: *compat.Io.Writer, allocator: Allocator) Serializer {
         return .{ .out = out, .allocator = allocator };
-    }
-
-    fn initBackpatch(out: *compat.Io.Writer, allocator: Allocator) Serializer {
-        return .{ .out = out, .allocator = allocator, .backpatch_containers = true };
     }
 
     pub fn serializeBool(self: *Serializer, value: bool) Error!void {
@@ -101,11 +80,6 @@ pub const Serializer = struct {
     }
 
     pub fn beginStruct(self: *Serializer) Error!StructSerializer {
-        if (self.backpatch_containers) {
-            const start = self.out.end;
-            self.out.writeAll(&.{ 0xdf, 0, 0, 0, 0 }) catch return error.WriteFailed;
-            return .{ .parent_out = self.out, .aw = undefined, .allocator = self.allocator, .field_count = 0, .backpatch = true, .start = start };
-        }
         return .{
             .parent_out = self.out,
             .aw = .init(self.allocator),
@@ -115,11 +89,6 @@ pub const Serializer = struct {
     }
 
     pub fn beginArray(self: *Serializer) Error!ArraySerializer {
-        if (self.backpatch_containers) {
-            const start = self.out.end;
-            self.out.writeAll(&.{ 0xdd, 0, 0, 0, 0 }) catch return error.WriteFailed;
-            return .{ .parent_out = self.out, .aw = undefined, .allocator = self.allocator, .elem_count = 0, .backpatch = true, .start = start };
-        }
         return .{
             .parent_out = self.out,
             .aw = .init(self.allocator),
@@ -137,29 +106,24 @@ pub const StructSerializer = struct {
     aw: compat.Io.Writer.Allocating,
     allocator: Allocator,
     field_count: u32,
-    backpatch: bool = false,
-    start: usize = 0,
 
     pub const Error = SerializeError;
 
     pub fn serializeField(self: *StructSerializer, comptime key: []const u8, value: anytype) Error!void {
-        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
+        var child = Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeString(key);
         try core_serialize.serialize(@TypeOf(value), value, &child, .{});
         self.field_count += 1;
     }
 
     pub fn serializeEntry(self: *StructSerializer, key: anytype, value: anytype) Error!void {
-        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
+        var child = Serializer.init(&self.aw.writer, self.allocator);
         try core_serialize.serialize(@TypeOf(key), key, &child, .{});
         try core_serialize.serialize(@TypeOf(value), value, &child, .{});
         self.field_count += 1;
     }
 
     pub fn end(self: *StructSerializer) Error!void {
-        if (self.backpatch) {
-            return finishBackpatch(self.parent_out, self.start, self.field_count, true);
-        }
         writeMapHeader(self.parent_out, self.field_count) catch {
             self.aw.deinit();
             return error.WriteFailed;
@@ -178,60 +142,53 @@ pub const ArraySerializer = struct {
     aw: compat.Io.Writer.Allocating,
     allocator: Allocator,
     elem_count: u32,
-    backpatch: bool = false,
-    start: usize = 0,
 
     pub const Error = SerializeError;
 
     pub fn serializeBool(self: *ArraySerializer, value: bool) Error!void {
-        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
+        var child = Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeBool(value);
         self.elem_count += 1;
     }
 
     pub fn serializeInt(self: *ArraySerializer, value: anytype) Error!void {
-        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
+        var child = Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeInt(value);
         self.elem_count += 1;
     }
 
     pub fn serializeFloat(self: *ArraySerializer, value: anytype) Error!void {
-        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
+        var child = Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeFloat(value);
         self.elem_count += 1;
     }
 
     pub fn serializeString(self: *ArraySerializer, value: []const u8) Error!void {
-        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
+        var child = Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeString(value);
         self.elem_count += 1;
     }
 
     pub fn serializeBytes(self: *ArraySerializer, value: []const u8) Error!void {
-        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
+        var child = Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeBytes(value);
         self.elem_count += 1;
     }
 
     pub fn serializeNull(self: *ArraySerializer) Error!void {
-        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
+        var child = Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeNull();
         self.elem_count += 1;
     }
 
     pub fn serializeVoid(self: *ArraySerializer) Error!void {
-        var child = if (self.backpatch) Serializer.initBackpatch(self.parent_out, self.allocator) else Serializer.init(&self.aw.writer, self.allocator);
+        var child = Serializer.init(&self.aw.writer, self.allocator);
         try child.serializeVoid();
         self.elem_count += 1;
     }
 
     pub fn beginStruct(self: *ArraySerializer) Error!StructSerializer {
         self.elem_count += 1;
-        if (self.backpatch) {
-            const start = self.parent_out.end;
-            self.parent_out.writeAll(&.{ 0xdf, 0, 0, 0, 0 }) catch return error.WriteFailed;
-            return .{ .parent_out = self.parent_out, .aw = undefined, .allocator = self.allocator, .field_count = 0, .backpatch = true, .start = start };
-        }
         return .{
             .parent_out = &self.aw.writer,
             .aw = .init(self.allocator),
@@ -242,11 +199,6 @@ pub const ArraySerializer = struct {
 
     pub fn beginArray(self: *ArraySerializer) Error!ArraySerializer {
         self.elem_count += 1;
-        if (self.backpatch) {
-            const start = self.parent_out.end;
-            self.parent_out.writeAll(&.{ 0xdd, 0, 0, 0, 0 }) catch return error.WriteFailed;
-            return .{ .parent_out = self.parent_out, .aw = undefined, .allocator = self.allocator, .elem_count = 0, .backpatch = true, .start = start };
-        }
         return .{
             .parent_out = &self.aw.writer,
             .aw = .init(self.allocator),
@@ -256,9 +208,6 @@ pub const ArraySerializer = struct {
     }
 
     pub fn end(self: *ArraySerializer) Error!void {
-        if (self.backpatch) {
-            return finishBackpatch(self.parent_out, self.start, self.elem_count, false);
-        }
         writeArrayHeader(self.parent_out, self.elem_count) catch {
             self.aw.deinit();
             return error.WriteFailed;
@@ -307,45 +256,6 @@ fn writeSint(out: *compat.Io.Writer, v: i64) !void {
     } else {
         try out.writeByte(0xd3);
         try out.writeAll(&toBE(u64, @bitCast(v)));
-    }
-}
-
-fn finishBackpatch(out: *compat.Io.Writer, start: usize, count: u32, map: bool) !void {
-    const header_len: usize = if (count <= 15) 1 else if (count <= 0xffff) 3 else 5;
-    if (start > out.end or out.end - start < 5)
-        return error.WriteFailed;
-    const payload_start = start + 5;
-    const payload_len = out.end - payload_start;
-    const shift = 5 - header_len;
-    if (shift != 0) {
-        std.mem.copyForwards(u8, out.buffer[start + header_len ..][0..payload_len], out.buffer[payload_start..][0..payload_len]);
-        out.end -= shift;
-    }
-    const header = out.buffer[start..][0..header_len];
-    if (map) writeMapHeaderFixed(header, count) else writeArrayHeaderFixed(header, count);
-}
-
-fn writeMapHeaderFixed(out: []u8, count: u32) void {
-    if (count <= 15) {
-        out[0] = @intCast(0x80 | count);
-    } else if (count <= 0xffff) {
-        out[0] = 0xde;
-        std.mem.writeInt(u16, out[1..3], @intCast(count), .big);
-    } else {
-        out[0] = 0xdf;
-        std.mem.writeInt(u32, out[1..5], count, .big);
-    }
-}
-
-fn writeArrayHeaderFixed(out: []u8, count: u32) void {
-    if (count <= 15) {
-        out[0] = @intCast(0x90 | count);
-    } else if (count <= 0xffff) {
-        out[0] = 0xdc;
-        std.mem.writeInt(u16, out[1..3], @intCast(count), .big);
-    } else {
-        out[0] = 0xdd;
-        std.mem.writeInt(u32, out[1..5], count, .big);
     }
 }
 

--- a/src/formats/msgpack/serializer.zig
+++ b/src/formats/msgpack/serializer.zig
@@ -4,7 +4,7 @@ const core_serialize = @import("../../core/serialize.zig");
 
 const Allocator = std.mem.Allocator;
 
-pub const SerializeError = error{ OutOfMemory, WriteFailed };
+pub const SerializeError = error{ OutOfMemory, WriteFailed, LengthOverflow };
 
 pub const Serializer = struct {
     out: *compat.Io.Writer,
@@ -101,11 +101,13 @@ pub const Serializer = struct {
     /// element count. The generic streaming API remains buffered because its
     /// final count may depend on runtime decisions.
     pub fn beginStructLen(self: *Serializer, len: usize) Error!DirectStructSerializer {
+        if (len > std.math.maxInt(u32)) return error.LengthOverflow;
         writeMapHeader(self.out, @intCast(len)) catch return error.WriteFailed;
         return .{ .out = self.out, .allocator = self.allocator };
     }
 
     pub fn beginArrayLen(self: *Serializer, len: usize) Error!DirectArraySerializer {
+        if (len > std.math.maxInt(u32)) return error.LengthOverflow;
         writeArrayHeader(self.out, @intCast(len)) catch return error.WriteFailed;
         return .{ .out = self.out, .allocator = self.allocator };
     }


### PR DESCRIPTION
My previous MessagePack PR improved the built-in benchmark, but broader testing with [serde.zig-benchmark](https://github.com/KercyDing/serde.zig-benchmark) showed that the backpatch approach regressed real-world encode performance.

The issue was that MessagePack reserved space for the largest container header, wrote the payload, then moved the payload when the final header was smaller. This works well for small values, but becomes expensive for large and nested containers.

This PR fixes that at the serde core level. When a container length is already known, the core passes it to serializers that support a length-aware API via `@hasDecl`. MessagePack can then write the final header first and stream the payload directly, without temporary buffers or backpatch moves.

## Results

Built-in MessagePack benchmark:

| Case | v1.0.7 | v1.0.8 | This PR |
| :---: | :---: | :---: | :---: |
| serialize / warm | 5,999 ns | 3,387 ns | **1,491 ns** |
| serialize / cold | 5,864 ns | 2,529 ns | **1,471 ns** |
| deserialize / warm | 9,051 ns | 4,116 ns | **3,147 ns** |
| roundtrip / warm | 7,367 ns | 3,173 ns | **3,095 ns** |

Real-world typed MessagePack encode, median of 100 process runs:

| Dataset | v1.0.7 | v1.0.8 | This PR |
| :---: | :---: | :---: | :---: |
| canada | 0.638 GB/s | 0.749 GB/s | **4.489 GB/s** |
| github_events | 1.714 GB/s | 1.371 GB/s | **3.428 GB/s** |
| poet | 3.181 GB/s | 2.397 GB/s | **6.829 GB/s** |
| twitter | 2.577 GB/s | 1.590 GB/s | **5.749 GB/s** |
| twitterescaped | 2.577 GB/s | 1.590 GB/s | **5.749 GB/s** |

Generic encode falls back to the buffered path and remains approximately at v1.0.7 performance.

I also changed unknown-value skipping from recursive traversal to an iterative pending-count loop. This avoids stack overflow on deeply nested unknown values and improves workloads that skip many fields.

## Testing

- `zig build test`
- `mise run ci-16`
- `zig build bench -Dbench-filter=msgpack`
- 100-run real-world comparisons against v1.0.7 and v1.0.8
- Added a test that skips 100,000 nested arrays
